### PR TITLE
feat: daemon mode, system services, Telegram streaming, and CLI overhaul

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -49,3 +49,18 @@
 - **Context**: Mercury needs to set reminders, run periodic tasks, and trigger skills on a schedule.
 - **Decision**: Expose `schedule_task`, `list_scheduled_tasks`, `cancel_scheduled_task` as AI-callable tools. Persist scheduled tasks to `~/.mercury/schedules.yaml`. Restore on startup. Tasks fire as internal (non-channel) messages through the agent loop.
 - **Consequence**: Mercury can autonomously schedule work. Tasks survive restarts. Internal execution keeps scheduled tasks invisible to channels unless the agent explicitly sends output.
+
+## ADR-009: Daemonization via Custom Hybrid Approach
+
+- **Context**: Mercury runs 24/7 but only in foreground mode. Closing the terminal kills the process, breaking Telegram, scheduled tasks, and heartbeat. Non-technical users should not need to install PM2/forever/systemd scripts manually.
+- **Decision**: Build a custom hybrid daemon manager natively into Mercury. No external dependencies. Uses three layers:
+  1. **Background spawn** — `child_process.spawn({detached: true})` + PID file + log redirect. Activated via `mercury start -d`.
+  2. **Watchdog** — Built-in crash recovery with exponential backoff (1s base, 1.25x, max 10 restarts/60s). Only active in daemon mode.
+  3. **Platform service generators** — `mercury service install` detects OS and generates the appropriate config: `systemd --user` unit on Linux, `~/Library/LaunchAgents` plist on macOS, startup shortcut on Windows. No root needed on Mac/Linux.
+- **Alternatives considered**:
+  - `node-windows/mac/linux` trio — partially unmaintained, requires sudo on Mac, node-linux is dead
+  - PM2 as dependency — 15MB, 50+ deps, AGPL-3.0 license
+  - PM2 as user install — requires non-technical users to learn a separate tool
+  - `forever` — officially deprecated by its own maintainers
+  - Native detached only — no crash recovery, no boot startup
+- **Consequence**: Zero external dependencies for core daemonization. Boot services are user-level (no sudo on Mac/Linux). Windows gets background mode + documented PM2 path. Foreground mode unchanged — daemon mode is opt-in. In daemon mode, CLI becomes log-only; Telegram (or other remote channels) is the interactive interface.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Type these during a conversation — they don't consume API tokens. Work on both
 | `/status` | Show agent config, budget, and usage |
 | `/tools` | List all loaded tools |
 | `/skills` | List installed skills |
+| `/stream` | Toggle Telegram text streaming |
+| `/stream off` | Disable streaming (single message) |
 | `/budget` | Show token budget status |
 | `/budget override` | Override budget for one request |
 | `/budget reset` | Reset usage to zero |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ mercury
 
 First run triggers the setup wizard — enter your name, an API key, and optionally a Telegram bot token. Takes 30 seconds.
 
+To reconfigure later (change keys, name, settings):
+
+```bash
+mercury doctor
+```
+
 ## Why Mercury?
 
 Every AI agent can read files, run commands, and fetch URLs. Most do it silently. **Mercury asks first.**
@@ -41,8 +47,82 @@ Every AI agent can read files, run commands, and fetch URLs. Most do it silently
 - **Soul-driven** — Personality defined by markdown files you own (`soul.md`, `persona.md`, `taste.md`, `heartbeat.md`). No corporate wrapper.
 - **Token-aware** — Daily budget enforcement. Auto-concise when over 70%. `/budget` command to check, reset, or override.
 - **Multi-channel** — CLI with real-time streaming. Telegram with HTML formatting, file uploads, and typing indicators.
-- **Always on** — Cron scheduling, delayed reminders, heartbeat monitoring, and proactive notifications.
+- **Always on** — Run as a background daemon on any OS. Auto-restarts on crash. Starts on boot. Cron scheduling, heartbeat monitoring, and proactive notifications.
 - **Extensible** — Install community skills with a single command. Schedule skills as recurring tasks. Based on the [Agent Skills](https://agentskills.io) specification.
+
+## Daemon Mode
+
+Run Mercury in the background so Telegram and scheduled tasks keep working after you close the terminal.
+
+```bash
+# Start in background
+mercury start -d
+
+# Check status
+mercury status
+
+# View logs
+mercury logs
+
+# Stop background process
+mercury stop
+```
+
+Daemon mode includes built-in crash recovery — if the process crashes, it restarts automatically with exponential backoff (up to 10 restarts per minute).
+
+### System Service (auto-start on boot)
+
+Install Mercury as a system service so it starts automatically:
+
+```bash
+mercury service install
+```
+
+| Platform | Method | Requires Admin |
+|----------|--------|---------------|
+| **macOS** | LaunchAgent (`~/Library/LaunchAgents/`) | No |
+| **Linux** | systemd user unit (`~/.config/systemd/user/`) | No (linger for boot) |
+| **Windows** | Task Scheduler (`schtasks`) | No |
+
+```bash
+mercury service status     # Check if service is running
+mercury service uninstall  # Remove the system service
+```
+
+In daemon mode, Telegram becomes your primary channel — CLI is log-only since there's no terminal for input.
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `mercury` | Start the agent (same as `mercury start`) |
+| `mercury start` | Start in foreground |
+| `mercury start -d` | Start in background (daemon mode) |
+| `mercury stop` | Stop a background process |
+| `mercury logs` | View recent daemon logs |
+| `mercury doctor` | Reconfigure (Enter to keep current values) |
+| `mercury setup` | Re-run the setup wizard |
+| `mercury status` | Show config and daemon status |
+| `mercury help` | Show full manual |
+| `mercury service install` | Install as system service (auto-start on boot) |
+| `mercury service uninstall` | Uninstall system service |
+| `mercury service status` | Show system service status |
+| `mercury --verbose` | Start with debug logging |
+
+## In-Chat Commands
+
+Type these during a conversation — they don't consume API tokens. Work on both CLI and Telegram.
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show the full manual |
+| `/status` | Show agent config, budget, and usage |
+| `/tools` | List all loaded tools |
+| `/skills` | List installed skills |
+| `/budget` | Show token budget status |
+| `/budget override` | Override budget for one request |
+| `/budget reset` | Reset usage to zero |
+| `/budget set <n>` | Change daily token budget |
 
 ## Built-in Tools
 
@@ -83,6 +163,8 @@ All runtime data lives in `~/.mercury/` — not in your project directory.
 | `~/.mercury/schedules.yaml` | Scheduled tasks |
 | `~/.mercury/token-usage.json` | Daily token usage tracking |
 | `~/.mercury/memory/` | Short-term, long-term, episodic memory |
+| `~/.mercury/daemon.pid` | Background process PID |
+| `~/.mercury/daemon.log` | Daemon mode logs |
 
 ## Provider Fallback
 
@@ -98,6 +180,8 @@ Configure multiple LLM providers. Mercury tries them in order and falls back aut
 - **Vercel AI SDK v4** — `generateText` + `streamText`, 10-step agentic loop, provider fallback
 - **grammY** — Telegram bot with typing indicators and file uploads
 - **Flat-file persistence** — No database. YAML + JSON in `~/.mercury/`
+- **Daemon manager** — Background spawn + PID file + watchdog crash recovery
+- **System services** — macOS LaunchAgent, Linux systemd, Windows Task Scheduler
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -52,27 +52,31 @@ Every AI agent can read files, run commands, and fetch URLs. Most do it silently
 
 ## Daemon Mode
 
-Run Mercury in the background so Telegram and scheduled tasks keep working after you close the terminal.
+**One command to make Mercury persistent:**
 
 ```bash
-# Start in background
-mercury start -d
+mercury up
+```
 
-# Check status
-mercury status
+This installs the system service (if not installed), starts the background daemon, and ensures Mercury is running. Use this as your go-to command.
 
-# View logs
-mercury logs
+If Mercury is already running, `mercury up` just confirms it and shows the PID.
 
-# Stop background process
-mercury stop
+### Other daemon commands
+
+```bash
+mercury restart      # Restart the background process
+mercury stop         # Stop the background process
+mercury start -d     # Start in background (without service install)
+mercury logs         # View recent daemon logs
+mercury status       # Show if daemon is running
 ```
 
 Daemon mode includes built-in crash recovery — if the process crashes, it restarts automatically with exponential backoff (up to 10 restarts per minute).
 
 ### System Service (auto-start on boot)
 
-Install Mercury as a system service so it starts automatically:
+`mercury up` installs this automatically. You can also manage it directly:
 
 ```bash
 mercury service install
@@ -95,9 +99,11 @@ In daemon mode, Telegram becomes your primary channel — CLI is log-only since 
 
 | Command | Description |
 |---------|-------------|
+| `mercury up` | **Recommended.** Install service + start daemon + ensure running |
 | `mercury` | Start the agent (same as `mercury start`) |
 | `mercury start` | Start in foreground |
 | `mercury start -d` | Start in background (daemon mode) |
+| `mercury restart` | Restart the background process |
 | `mercury stop` | Stop a background process |
 | `mercury logs` | View recent daemon logs |
 | `mercury doctor` | Reconfigure (Enter to keep current values) |

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -291,6 +291,18 @@
       </div>
 
       <h2 id="starting">Starting Mercury</h2>
+
+      <div class="callout" style="border-left-color: var(--cyan); background: rgba(0, 212, 255, 0.06);">
+        <div class="callout-title">Recommended: mercury up</div>
+        <p>The easiest way to run Mercury persistently. Installs the system service if needed, starts the daemon, and
+          ensures it's running.</p>
+      </div>
+      <div class="terminal-inline">
+        <code>mercury up</code>
+      </div>
+      <p>If Mercury is already running, <code>mercury up</code> just confirms it and shows the PID. If the service isn't
+        installed yet, it installs it first, then starts the daemon.</p>
+
       <h3>Foreground (interactive)</h3>
       <div class="terminal-inline">
         <code>mercury start</code>
@@ -325,6 +337,10 @@
         </thead>
         <tbody>
           <tr>
+            <td>mercury up</td>
+            <td><strong>Recommended.</strong> Install service + start daemon + ensure running</td>
+          </tr>
+          <tr>
             <td>mercury</td>
             <td>Start the agent (same as <code>mercury start</code>)</td>
           </tr>
@@ -335,6 +351,10 @@
           <tr>
             <td>mercury start -d</td>
             <td>Start in background (daemon mode)</td>
+          </tr>
+          <tr>
+            <td>mercury restart</td>
+            <td>Restart a background Mercury process</td>
           </tr>
           <tr>
             <td>mercury stop</td>
@@ -440,6 +460,13 @@
       <h2 id="daemon">Daemon Mode</h2>
       <p>Mercury can run in the background so Telegram and scheduled tasks keep working after you close the terminal.</p>
 
+      <h3>The easy way: mercury up</h3>
+      <div class="terminal-inline">
+        <code>mercury up</code>
+      </div>
+      <p>This one command does everything: installs the system service if needed, starts the background daemon, and
+        confirms Mercury is running. If it's already running, it just shows you the PID.</p>
+
       <h3>Start in background</h3>
       <div class="terminal-inline">
         <code>mercury start -d</code>
@@ -453,6 +480,13 @@
       </div>
       <p>Sends <code>SIGTERM</code> (<code>process.kill</code> on Windows) to the background process and removes the PID
         file.</p>
+
+      <h3>Restart</h3>
+      <div class="terminal-inline">
+        <code>mercury restart</code>
+      </div>
+      <p>Stops the running daemon (if any) and starts a fresh one. Useful when something isn't working right and you need a
+        clean restart.</p>
 
       <h3>View logs</h3>
       <div class="terminal-inline">

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -439,6 +439,14 @@
             <td>List installed skills</td>
           </tr>
           <tr>
+            <td>/stream</td>
+            <td>Toggle Telegram text streaming (on/off)</td>
+          </tr>
+          <tr>
+            <td>/stream off</td>
+            <td>Disable streaming — responses arrive as single message</td>
+          </tr>
+          <tr>
             <td>/budget</td>
             <td>Show token budget status</td>
           </tr>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1,0 +1,922 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mercury Documentation — Installation, Commands, and Daemon Mode</title>
+  <meta name="description"
+    content="Complete documentation for Mercury AI agent. Installation, CLI commands, daemon mode, in-chat commands, configuration, and platform-specific service setup.">
+  <meta name="author" content="Cosmic Stack">
+  <meta name="robots" content="index, follow">
+  <meta name="theme-color" content="#0a0a0a">
+  <link rel="canonical" href="https://mercury.cosmicstack.org/docs.html">
+  <link rel="icon"
+    href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☿</text></svg>">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .docs-layout {
+      display: grid;
+      grid-template-columns: 240px 1fr;
+      gap: 48px;
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 32px 24px 100px;
+    }
+
+    .docs-sidebar {
+      position: sticky;
+      top: 72px;
+      align-self: start;
+      max-height: calc(100vh - 96px);
+      overflow-y: auto;
+    }
+
+    .docs-sidebar nav {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .docs-sidebar a {
+      color: var(--gray);
+      font-size: 0.9em;
+      padding: 6px 12px;
+      border-radius: 6px;
+      text-decoration: none;
+      transition: all 0.2s;
+    }
+
+    .docs-sidebar a:hover,
+    .docs-sidebar a.active {
+      color: var(--cyan);
+      background: var(--cyan-glow);
+    }
+
+    .docs-sidebar .sidebar-heading {
+      font-family: var(--font);
+      font-size: 0.75em;
+      color: var(--gray-dim);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-top: 20px;
+      margin-bottom: 4px;
+      padding-left: 12px;
+    }
+
+    .docs-content h2 {
+      font-size: 1.6em;
+      margin-top: 56px;
+      margin-bottom: 12px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border);
+    }
+
+    .docs-content h2:first-child {
+      margin-top: 0;
+      border-top: none;
+    }
+
+    .docs-content h3 {
+      font-size: 1.15em;
+      margin-top: 32px;
+      margin-bottom: 8px;
+    }
+
+    .docs-content p {
+      color: var(--gray);
+      line-height: 1.75;
+      margin-bottom: 16px;
+    }
+
+    .docs-content ul,
+    .docs-content ol {
+      color: var(--gray);
+      margin-left: 20px;
+      margin-bottom: 16px;
+      line-height: 1.8;
+    }
+
+    .docs-content li {
+      margin-bottom: 4px;
+    }
+
+    .docs-content strong {
+      color: var(--white);
+    }
+
+    .cmd-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 16px 0 24px;
+    }
+
+    .cmd-table th {
+      text-align: left;
+      padding: 10px 16px;
+      background: var(--bg-card);
+      color: var(--cyan);
+      font-family: var(--font);
+      font-size: 0.8em;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .cmd-table td {
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      color: var(--gray);
+      font-size: 0.92em;
+    }
+
+    .cmd-table td:first-child {
+      font-family: var(--font);
+      color: var(--cyan);
+      white-space: nowrap;
+    }
+
+    .cmd-table tr:hover td {
+      background: rgba(0, 212, 255, 0.03);
+    }
+
+    .platform-tabs {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 20px;
+    }
+
+    .platform-tab {
+      font-family: var(--font);
+      font-size: 0.85em;
+      padding: 8px 20px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--gray);
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .platform-tab:hover {
+      border-color: var(--cyan-dim);
+      color: var(--white);
+    }
+
+    .platform-tab.active {
+      border-color: var(--cyan);
+      color: var(--cyan);
+      background: var(--cyan-glow);
+    }
+
+    .platform-content {
+      display: none;
+    }
+
+    .platform-content.active {
+      display: block;
+    }
+
+    .callout {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-left: 3px solid var(--cyan);
+      border-radius: 8px;
+      padding: 16px 20px;
+      margin: 20px 0;
+    }
+
+    .callout p {
+      margin-bottom: 0;
+    }
+
+    .callout-title {
+      color: var(--cyan);
+      font-weight: 600;
+      font-size: 0.95em;
+      margin-bottom: 4px;
+    }
+
+    @media (max-width: 900px) {
+      .docs-layout {
+        grid-template-columns: 1fr;
+      }
+
+      .docs-sidebar {
+        position: static;
+        max-height: none;
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 16px;
+        margin-bottom: 16px;
+      }
+
+      .docs-sidebar nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 4px;
+      }
+
+      .docs-sidebar .sidebar-heading {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <nav id="nav">
+    <div class="nav-inner">
+      <a href="index.html" class="nav-logo">☿ Mercury</a>
+      <div class="nav-links" id="navLinks">
+        <a href="index.html">Home</a>
+        <a href="docs.html" style="color: var(--cyan);">Docs</a>
+        <a href="https://github.com/cosmicstack-labs/mercury-agent" class="nav-cta" target="_blank"
+          rel="noopener">GitHub</a>
+      </div>
+      <button class="nav-toggle" id="navToggle" aria-label="Menu">☰</button>
+    </div>
+  </nav>
+
+  <div class="docs-layout" style="margin-top: 80px;">
+    <aside class="docs-sidebar">
+      <nav>
+        <div class="sidebar-heading">Getting Started</div>
+        <a href="#installation">Installation</a>
+        <a href="#setup">First-Time Setup</a>
+        <a href="#starting">Starting Mercury</a>
+        <div class="sidebar-heading">CLI Commands</div>
+        <a href="#cli-commands">Full Command Reference</a>
+        <a href="#doctor">Doctor (Reconfigure)</a>
+        <a href="#in-chat">In-Chat Commands</a>
+        <div class="sidebar-heading">Daemon Mode</div>
+        <a href="#daemon">Background Mode</a>
+        <a href="#service">System Service</a>
+        <a href="#platform-guide">Platform Guide</a>
+        <div class="sidebar-heading">Reference</div>
+        <a href="#tools">Built-in Tools</a>
+        <a href="#configuration">Configuration</a>
+        <a href="#permissions">Permissions</a>
+        <a href="#providers">Provider Fallback</a>
+        <a href="#scheduling">Scheduling</a>
+        <a href="#skills">Skills</a>
+      </nav>
+    </aside>
+
+    <main class="docs-content">
+
+      <h2 id="installation">Installation</h2>
+      <p>Mercury requires <strong>Node.js 20+</strong>. Install with npm:</p>
+      <div class="terminal-inline">
+        <code>npm i -g @cosmicstack/mercury-agent</code>
+      </div>
+      <p>Or run without installing:</p>
+      <div class="terminal-inline">
+        <code>npx @cosmicstack/mercury-agent</code>
+      </div>
+
+      <h2 id="setup">First-Time Setup</h2>
+      <p>Run <code>mercury</code> for the first time. The onboarding wizard asks for:</p>
+      <ul>
+        <li><strong>Your name</strong> — used by the agent to address you</li>
+        <li><strong>Agent name</strong> — defaults to "Mercury", customize it</li>
+        <li><strong>LLM API keys</strong> — at least one: DeepSeek, OpenAI, or Anthropic</li>
+        <li><strong>Telegram bot token</strong> — optional, for remote access</li>
+      </ul>
+      <p>All config is stored in <code>~/.mercury/</code> — nothing in your project directory.</p>
+
+      <div class="callout">
+        <div class="callout-title">Masked keys</div>
+        <p>When reconfiguring with <code>mercury doctor</code>, existing API keys are shown masked like
+          <code>sk-x••••4f2a</code>. Press Enter to keep the current value, or paste a new key to replace it.</p>
+      </div>
+
+      <h2 id="starting">Starting Mercury</h2>
+      <h3>Foreground (interactive)</h3>
+      <div class="terminal-inline">
+        <code>mercury start</code>
+      </div>
+      <p>Runs in the foreground with a readline prompt. Press <code>Ctrl+C</code> to exit. All conversation happens in
+        your terminal with real-time text streaming and markdown rendering.</p>
+
+      <h3>Background (daemon)</h3>
+      <div class="terminal-inline">
+        <code>mercury start -d</code>
+      </div>
+      <p>Runs in the background. Telegram becomes your primary interface since there's no terminal for input. Logs go to
+        <code>~/.mercury/daemon.log</code>. The process includes built-in crash recovery with exponential backoff.</p>
+      <p>When running in daemon mode, you can stop it with:</p>
+      <div class="terminal-inline">
+        <code>mercury stop</code>
+      </div>
+
+      <h3>Verbose logging</h3>
+      <p>Add <code>--verbose</code> to any start command to see debug logs on stderr:</p>
+      <div class="terminal-inline">
+        <code>mercury start --verbose</code>
+      </div>
+
+      <h2 id="cli-commands">Full Command Reference</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Command</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>mercury</td>
+            <td>Start the agent (same as <code>mercury start</code>)</td>
+          </tr>
+          <tr>
+            <td>mercury start</td>
+            <td>Start in foreground mode</td>
+          </tr>
+          <tr>
+            <td>mercury start -d</td>
+            <td>Start in background (daemon mode)</td>
+          </tr>
+          <tr>
+            <td>mercury stop</td>
+            <td>Stop a background Mercury process</td>
+          </tr>
+          <tr>
+            <td>mercury logs</td>
+            <td>Show last 100 lines of daemon logs</td>
+          </tr>
+          <tr>
+            <td>mercury status</td>
+            <td>Show config, providers, daemon PID, and budget</td>
+          </tr>
+          <tr>
+            <td>mercury doctor</td>
+            <td>Reconfigure settings — press Enter to keep current values</td>
+          </tr>
+          <tr>
+            <td>mercury setup</td>
+            <td>Re-run the setup wizard (same as doctor)</td>
+          </tr>
+          <tr>
+            <td>mercury help</td>
+            <td>Show the full manual (tools, commands, config paths)</td>
+          </tr>
+          <tr>
+            <td>mercury service install</td>
+            <td>Install as system service (auto-start on boot)</td>
+          </tr>
+          <tr>
+            <td>mercury service uninstall</td>
+            <td>Uninstall the system service</td>
+          </tr>
+          <tr>
+            <td>mercury service status</td>
+            <td>Show system service status</td>
+          </tr>
+          <tr>
+            <td>mercury --verbose</td>
+            <td>Start with debug logging on stderr</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="doctor">Doctor (Reconfigure)</h2>
+      <p><code>mercury doctor</code> re-runs the setup wizard with your current values pre-filled. Press <strong>Enter</strong>
+        on any field to keep it unchanged, or type a new value to replace it.</p>
+      <ul>
+        <li><strong>API keys</strong> are shown masked: <code>sk-x••••4f2a</code></li>
+        <li><strong>Telegram token</strong> — type <code>none</code> to disable Telegram</li>
+        <li><strong>Daily budget</strong> — change the token budget limit</li>
+      </ul>
+      <div class="terminal-inline">
+        <code>mercury doctor</code>
+      </div>
+
+      <h2 id="in-chat">In-Chat Commands</h2>
+      <p>Type these during a conversation with Mercury — they work on both CLI and Telegram. They <strong>do not consume
+          API tokens</strong>.</p>
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Command</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>/help</td>
+            <td>Show the full manual</td>
+          </tr>
+          <tr>
+            <td>/status</td>
+            <td>Show agent name, provider, budget, and channels</td>
+          </tr>
+          <tr>
+            <td>/tools</td>
+            <td>List all currently loaded tools</td>
+          </tr>
+          <tr>
+            <td>/skills</td>
+            <td>List installed skills</td>
+          </tr>
+          <tr>
+            <td>/budget</td>
+            <td>Show token budget status</td>
+          </tr>
+          <tr>
+            <td>/budget override</td>
+            <td>Override budget for one request</td>
+          </tr>
+          <tr>
+            <td>/budget reset</td>
+            <td>Reset usage to zero</td>
+          </tr>
+          <tr>
+            <td>/budget set &lt;n&gt;</td>
+            <td>Change daily token budget</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="daemon">Daemon Mode</h2>
+      <p>Mercury can run in the background so Telegram and scheduled tasks keep working after you close the terminal.</p>
+
+      <h3>Start in background</h3>
+      <div class="terminal-inline">
+        <code>mercury start -d</code>
+      </div>
+      <p>This spawns a detached child process, writes a PID file to <code>~/.mercury/daemon.pid</code>, and redirects
+        output to <code>~/.mercury/daemon.log</code>.</p>
+
+      <h3>Stop</h3>
+      <div class="terminal-inline">
+        <code>mercury stop</code>
+      </div>
+      <p>Sends <code>SIGTERM</code> (<code>process.kill</code> on Windows) to the background process and removes the PID
+        file.</p>
+
+      <h3>View logs</h3>
+      <div class="terminal-inline">
+        <code>mercury logs</code>
+      </div>
+      <p>Shows the last 100 lines of <code>~/.mercury/daemon.log</code>.</p>
+
+      <h3>Check status</h3>
+      <div class="terminal-inline">
+        <code>mercury status</code>
+      </div>
+      <p>Shows whether the daemon is running, its PID, and the log file path.</p>
+
+      <div class="callout">
+        <div class="callout-title">Crash recovery</div>
+        <p>When started with <code>--daemon</code> (internal flag used by <code>start -d</code> and system services),
+          Mercury wraps the agent in a watchdog. If it crashes, it restarts automatically with exponential backoff (1s,
+          1.25s, 1.56s...). After 10 crashes within 60 seconds, it exits to prevent crash loops.</p>
+      </div>
+
+      <h2 id="service">System Service (Auto-Start on Boot)</h2>
+      <p>Install Mercury as a system service so it starts automatically on boot and restarts on crash.</p>
+      <div class="terminal-inline">
+        <code>mercury service install</code>
+      </div>
+      <p>This detects your platform and generates the appropriate service config.</p>
+
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Platform</th>
+            <th>Method</th>
+            <th>Requires Admin</th>
+            <th>Auto-Start</th>
+            <th>Crash Recovery</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>macOS</td>
+            <td>LaunchAgent plist</td>
+            <td>No</td>
+            <td>On login</td>
+            <td>KeepAlive (restart on crash)</td>
+          </tr>
+          <tr>
+            <td>Linux</td>
+            <td>systemd user unit</td>
+            <td>No*</td>
+            <td>On login</td>
+            <td>Restart=on-failure, 5s delay</td>
+          </tr>
+          <tr>
+            <td>Windows</td>
+            <td>Task Scheduler (schtasks)</td>
+            <td>No</td>
+            <td>On logon</td>
+            <td>Built-in watchdog</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p><em>*Linux boot-without-login requires <code>loginctl enable-linger $USER</code> (one-time, needs sudo).</em>
+      </p>
+
+      <h3>Other service commands</h3>
+      <div class="terminal-inline">
+        <code>mercury service status</code>
+      </div>
+      <div class="terminal-inline">
+        <code>mercury service uninstall</code>
+      </div>
+
+      <h2 id="platform-guide">Platform-Specific Guide</h2>
+
+      <div class="platform-tabs">
+        <button class="platform-tab active"
+          onclick="showPlatform('macos', this)">macOS</button>
+        <button class="platform-tab"
+          onclick="showPlatform('linux', this)">Linux</button>
+        <button class="platform-tab"
+          onclick="showPlatform('windows', this)">Windows</button>
+      </div>
+
+      <div id="platform-macos" class="platform-content active">
+        <p><code>mercury service install</code> creates a LaunchAgent at
+          <code>~/Library/LaunchAgents/com.cosmicstack.mercury.plist</code>.</p>
+        <ul>
+          <li><strong>Auto-start</strong>: Loads on login via <code>launchctl load</code></li>
+          <li><strong>Crash recovery</strong>: <code>KeepAlive SuccessfulExit = false</code> restarts on crash</li>
+          <li><strong>No sudo needed</strong>: User-level LaunchAgent, not system daemon</li>
+          <li><strong>Logs</strong>: <code>~/.mercury/daemon.log</code> and <code>~/.mercury/daemon-error.log</code></li>
+        </ul>
+        <h3>Manual management</h3>
+        <div class="terminal-inline">
+          <code>launchctl load ~/Library/LaunchAgents/com.cosmicstack.mercury.plist</code>
+        </div>
+        <div class="terminal-inline">
+          <code>launchctl unload ~/Library/LaunchAgents/com.cosmicstack.mercury.plist</code>
+        </div>
+      </div>
+
+      <div id="platform-linux" class="platform-content">
+        <p><code>mercury service install</code> creates a systemd user unit at
+          <code>~/.config/systemd/user/mercury.service</code>.</p>
+        <ul>
+          <li><strong>Auto-start</strong>: Enabled via <code>systemctl --user enable mercury.service</code></li>
+          <li><strong>Crash recovery</strong>: <code>Restart=on-failure</code> with 5s delay</li>
+          <li><strong>No sudo needed</strong>: User-level service</li>
+          <li><strong>Boot without login</strong>: Run <code>sudo loginctl enable-linger $USER</code> once</li>
+          <li><strong>Logs</strong>: <code>~/.mercury/daemon.log</code> or <code>journalctl --user -u mercury</code></li>
+        </ul>
+        <h3>Manual management</h3>
+        <div class="terminal-inline">
+          <code>systemctl --user start mercury</code>
+        </div>
+        <div class="terminal-inline">
+          <code>systemctl --user status mercury</code>
+        </div>
+        <div class="terminal-inline">
+          <code>systemctl --user stop mercury</code>
+        </div>
+      </div>
+
+      <div id="platform-windows" class="platform-content">
+        <p><code>mercury service install</code> creates a Windows Task Scheduler task named <code>MercuryAgent</code>.
+        </p>
+        <ul>
+          <li><strong>Auto-start</strong>: Triggers on user logon via <code>schtasks</code></li>
+          <li><strong>Crash recovery</strong>: Built-in watchdog with exponential backoff</li>
+          <li><strong>No admin needed</strong>: Runs with limited privileges (<code>/rl limited</code>)</li>
+          <li><strong>Logs</strong>: <code>%USERPROFILE%\.mercury\daemon.log</code></li>
+        </ul>
+        <h3>Manual management</h3>
+        <div class="terminal-inline">
+          <code>schtasks /query /tn "MercuryAgent" /fo list</code>
+        </div>
+        <div class="terminal-inline">
+          <code>schtasks /run /tn "MercuryAgent"</code>
+        </div>
+        <div class="terminal-inline">
+          <code>schtasks /delete /tn "MercuryAgent" /f</code>
+        </div>
+      </div>
+
+      <h2 id="tools">Built-in Tools</h2>
+      <p>Mercury has 21 built-in tools it can use during conversations. These are not CLI commands — the agent decides
+        when to call them.</p>
+
+      <h3>Filesystem</h3>
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>What it does</th>
+            <th>Parameters</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>read_file</td>
+            <td>Read file contents</td>
+            <td>path</td>
+          </tr>
+          <tr>
+            <td>write_file</td>
+            <td>Write to an existing file</td>
+            <td>path, content</td>
+          </tr>
+          <tr>
+            <td>create_file</td>
+            <td>Create a new file (creates parent dirs)</td>
+            <td>path, content</td>
+          </tr>
+          <tr>
+            <td>edit_file</td>
+            <td>Search and replace text in a file</td>
+            <td>path, old_string, new_string</td>
+          </tr>
+          <tr>
+            <td>list_dir</td>
+            <td>List directory contents</td>
+            <td>path</td>
+          </tr>
+          <tr>
+            <td>delete_file</td>
+            <td>Delete a file</td>
+            <td>path</td>
+          </tr>
+          <tr>
+            <td>send_file</td>
+            <td>Send file to user (Telegram upload)</td>
+            <td>path</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Shell</h3>
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>What it does</th>
+            <th>Parameters</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>run_command</td>
+            <td>Execute a shell command</td>
+            <td>command</td>
+          </tr>
+          <tr>
+            <td>approve_command</td>
+            <td>Permanently approve a command type</td>
+            <td>command (e.g. "curl")</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Git</h3>
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>What it does</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>git_status</td>
+            <td>Working tree status</td>
+          </tr>
+          <tr>
+            <td>git_diff</td>
+            <td>Show file changes</td>
+          </tr>
+          <tr>
+            <td>git_log</td>
+            <td>Commit history</td>
+          </tr>
+          <tr>
+            <td>git_add</td>
+            <td>Stage files</td>
+          </tr>
+          <tr>
+            <td>git_commit</td>
+            <td>Create a commit</td>
+          </tr>
+          <tr>
+            <td>git_push</td>
+            <td>Push to remote (needs approval)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Web, Skills, Scheduler, System</h3>
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>What it does</th>
+            <th>Category</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>fetch_url</td>
+            <td>Fetch a URL and return content (HTML stripped)</td>
+            <td>Web</td>
+          </tr>
+          <tr>
+            <td>install_skill</td>
+            <td>Install a skill from URL or content</td>
+            <td>Skills</td>
+          </tr>
+          <tr>
+            <td>list_skills</td>
+            <td>List installed skills</td>
+            <td>Skills</td>
+          </tr>
+          <tr>
+            <td>use_skill</td>
+            <td>Invoke a skill by name</td>
+            <td>Skills</td>
+          </tr>
+          <tr>
+            <td>schedule_task</td>
+            <td>Schedule recurring (cron) or one-shot (delay) task</td>
+            <td>Scheduler</td>
+          </tr>
+          <tr>
+            <td>list_scheduled_tasks</td>
+            <td>View all scheduled tasks</td>
+            <td>Scheduler</td>
+          </tr>
+          <tr>
+            <td>cancel_scheduled_task</td>
+            <td>Cancel a scheduled task</td>
+            <td>Scheduler</td>
+          </tr>
+          <tr>
+            <td>budget_status</td>
+            <td>Check token budget usage</td>
+            <td>System</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="configuration">Configuration</h2>
+      <p>All runtime data lives in <code>~/.mercury/</code> — not in your project directory.</p>
+      <table class="cmd-table">
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>~/.mercury/mercury.yaml</td>
+            <td>Main config (providers, channels, budget)</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/soul/*.md</td>
+            <td>Agent personality (soul, persona, taste, heartbeat)</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/permissions.yaml</td>
+            <td>Capabilities and approval rules</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/skills/</td>
+            <td>Installed skills</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/schedules.yaml</td>
+            <td>Scheduled tasks</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/token-usage.json</td>
+            <td>Daily token usage tracking</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/memory/</td>
+            <td>Short-term, long-term, episodic memory</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/daemon.pid</td>
+            <td>Background process PID</td>
+          </tr>
+          <tr>
+            <td>~/.mercury/daemon.log</td>
+            <td>Daemon mode logs</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="permissions">Permissions</h2>
+      <p>Mercury has a three-tier permission system for shell commands:</p>
+      <ol>
+        <li><strong>Blocked</strong> — Commands like <code>sudo</code>, <code>rm -rf /</code>, <code>mkfs</code> are
+          never executed</li>
+        <li><strong>Auto-approved</strong> — Safe commands like <code>ls</code>, <code>cat</code>, <code>git status</code>
+          run without asking</li>
+        <li><strong>Pending approval</strong> — Unknown commands pause and ask you. Say <strong>"always"</strong> to
+          permanently approve a command type</li>
+      </ol>
+      <p>Edit <code>~/.mercury/permissions.yaml</code> to customize. Skill elevation: skills with <code>allowed-tools
+      </code> in their SKILL.md get automatic approval for those tools during execution.</p>
+
+      <h2 id="providers">Provider Fallback</h2>
+      <p>Configure multiple LLM providers. Mercury tries them in order and falls back automatically:</p>
+      <ul>
+        <li><strong>DeepSeek</strong> — default, cost-effective</li>
+        <li><strong>OpenAI</strong> — GPT-4o-mini and others</li>
+        <li><strong>Anthropic</strong> — Claude and others</li>
+      </ul>
+      <p>When a provider fails, Mercury automatically tries the next one. It remembers the last successful provider and
+        starts there on the next request.</p>
+
+      <h2 id="scheduling">Scheduling</h2>
+      <p>Mercury can schedule tasks using cron expressions or one-shot delays.</p>
+      <h3>Recurring tasks</h3>
+      <p>Tell Mercury in conversation:</p>
+      <ul>
+        <li>"Remind me every day at 9am to check the server"</li>
+        <li>"Schedule a weekly summary every Monday at 10am"</li>
+      </ul>
+      <h3>One-shot delays</h3>
+      <ul>
+        <li>"Remind me in 15 minutes to take a break"</li>
+        <li>"Ping me in 2 hours about the deployment"</li>
+      </ul>
+      <p>Tasks persist to <code>~/.mercury/schedules.yaml</code> and restore on restart. Responses route back to the
+        channel (CLI or Telegram) where the task was created.</p>
+
+      <h2 id="skills">Skills</h2>
+      <p>Skills are markdown-based extensions that live in <code>~/.mercury/skills/&lt;name&gt;/SKILL.md</code>.</p>
+      <h3>Installing</h3>
+      <p>Tell Mercury in conversation:</p>
+      <ul>
+        <li>"Install skill from https://example.com/my-skill.md"</li>
+        <li>Or paste the SKILL.md content directly</li>
+      </ul>
+      <h3>Invoking</h3>
+      <ul>
+        <li>"Use the daily-digest skill"</li>
+      </ul>
+      <h3>Scheduling a skill</h3>
+      <ul>
+        <li>"Remind me daily at 9am to run the daily-digest skill"</li>
+      </ul>
+      <p>Skills follow the <a href="https://agentskills.io" target="_blank" rel="noopener">Agent Skills specification</a>.
+        They get elevated permissions via <code>allowed-tools</code> and are loaded with progressive disclosure to save
+        tokens.</p>
+
+    </main>
+  </div>
+
+  <footer>
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <span class="footer-logo">☿ Mercury</span>
+        <span class="footer-tagline">by Cosmic Stack</span>
+      </div>
+      <div class="footer-links">
+        <a href="https://mercury.cosmicstack.org">mercury.cosmicstack.org</a>
+        <a href="https://github.com/cosmicstack-labs/mercury-agent">GitHub</a>
+        <a href="https://github.com/cosmicstack-labs/mercury-agent/issues">Issues</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="app.js"></script>
+  <script>
+    function showPlatform(id, btn) {
+      document.querySelectorAll('.platform-content').forEach(el => el.classList.remove('active'));
+      document.querySelectorAll('.platform-tab').forEach(el => el.classList.remove('active'));
+      document.getElementById('platform-' + id).classList.add('active');
+      btn.classList.add('active');
+    }
+
+    // Highlight sidebar on scroll
+    const sidebarLinks = document.querySelectorAll('.docs-sidebar a');
+    const sections = [];
+    sidebarLinks.forEach(link => {
+      const id = link.getAttribute('href')?.slice(1);
+      if (id) {
+        const el = document.getElementById(id);
+        if (el) sections.push({ link, el });
+      }
+    });
+
+    window.addEventListener('scroll', () => {
+      const scrollY = window.scrollY + 100;
+      let current = sections[0];
+      for (const s of sections) {
+        if (s.el.offsetTop <= scrollY) current = s;
+      }
+      sidebarLinks.forEach(l => l.classList.remove('active'));
+      if (current) current.link.classList.add('active');
+    }, { passive: true });
+  </script>
+</body>
+
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,6 +81,7 @@
         <a href="#demo">Demo</a>
         <a href="#capabilities">Capabilities</a>
         <a href="#compare">Compare</a>
+        <a href="docs.html">Docs</a>
         <a href="https://github.com/cosmicstack-labs/mercury-agent" class="nav-cta" target="_blank"
           rel="noopener">GitHub</a>
       </div>
@@ -137,8 +138,7 @@
         <div class="feature-card" data-reveal>
           <div class="feature-icon">♾</div>
           <h3>Always On</h3>
-          <p>Cron scheduling, delayed tasks, and a heartbeat system that monitors budget and upcoming tasks. Mercury
-            runs 24/7 and notifies you proactively via Telegram or CLI.</p>
+          <p>Cron scheduling, delayed tasks, and a heartbeat system that monitors budget and upcoming tasks. Run as a background daemon on macOS, Linux, or Windows. Auto-starts on boot, auto-restarts on crash.</p>
         </div>
         <div class="feature-card" data-reveal>
           <div class="feature-icon">📡</div>
@@ -189,7 +189,7 @@
           <div class="terminal-inline">
             <code>mercury start</code>
           </div>
-          <p>Mercury wakes up, loads your soul files, restores scheduled tasks, and is live. Start talking.</p>
+          <p>Mercury wakes up, loads your soul files, restores scheduled tasks, and is live. Start talking. Or use <code>mercury start -d</code> for background mode.</p>
         </div>
       </div>
     </div>
@@ -391,6 +391,53 @@
     </div>
   </section>
 
+  <section id="daemon" class="section section-dark">
+    <div class="container">
+      <h2 class="section-title">Always On. Any Platform.</h2>
+      <p class="section-sub">Run Mercury as a background daemon. Auto-starts on boot. Auto-restarts on crash.</p>
+      <div class="terminal-window" style="max-width: 680px; margin: 0 auto 48px;">
+        <div class="terminal-bar">
+          <span class="terminal-dot red"></span>
+          <span class="terminal-dot yellow"></span>
+          <span class="terminal-dot green"></span>
+          <span class="terminal-title">terminal</span>
+        </div>
+        <div class="terminal-body" style="min-height: auto; padding: 16px 24px;">
+          <p style="margin:0;color:var(--gray);">$ <span style="color:var(--cyan);">mercury start -d</span></p>
+          <p style="margin:0;color:var(--white);">Mercury started in background (PID: 48291)</p>
+          <p style="margin:0;color:var(--gray-dim);">Logs: ~/.mercury/daemon.log</p>
+          <p style="margin:0;color:var(--gray-dim);">Use `mercury stop` to stop.</p>
+          <p style="margin:8px 0 0;color:var(--gray);">$ <span style="color:var(--cyan);">mercury service install</span></p>
+          <p style="margin:0;color:var(--green);">Mercury service installed (macOS LaunchAgent)</p>
+          <p style="margin:0;color:var(--gray-dim);">Auto-starts on login. Auto-restarts on crash.</p>
+        </div>
+      </div>
+      <div class="caps-grid" style="max-width: 900px; margin: 0 auto;">
+        <div class="cap-group" data-reveal>
+          <h3>Commands</h3>
+          <ul>
+            <li><code>mercury start -d</code> — Background daemon</li>
+            <li><code>mercury stop</code> — Stop background process</li>
+            <li><code>mercury logs</code> — View daemon logs</li>
+            <li><code>mercury service install</code> — Auto-start on boot</li>
+            <li><code>mercury doctor</code> — Reconfigure (Enter keeps values)</li>
+            <li><code>/help</code> <code>/status</code> <code>/budget</code> — In-chat commands</li>
+          </ul>
+        </div>
+        <div class="cap-group" data-reveal>
+          <h3>Platform Support</h3>
+          <ul>
+            <li><strong>macOS</strong> — LaunchAgent (no sudo)</li>
+            <li><strong>Linux</strong> — systemd user unit (no sudo)</li>
+            <li><strong>Windows</strong> — Task Scheduler (no admin)</li>
+            <li><strong>Crash recovery</strong> — Exponential backoff watchdog</li>
+            <li><strong>Zero deps</strong> — No PM2, forever, or NSSM needed</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section id="architecture" class="section section-dark">
     <div class="container">
       <h2 class="section-title">Under the Hood</h2>
@@ -452,6 +499,7 @@
         <span class="footer-tagline">by Cosmic Stack</span>
       </div>
       <div class="footer-links">
+        <a href="docs.html">Docs</a>
         <a href="https://mercury.cosmicstack.org">mercury.cosmicstack.org</a>
         <a href="https://github.com/cosmicstack-labs/mercury-agent">GitHub</a>
         <a href="https://github.com/cosmicstack-labs/mercury-agent/issues">Issues</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -403,12 +403,11 @@
           <span class="terminal-title">terminal</span>
         </div>
         <div class="terminal-body" style="min-height: auto; padding: 16px 24px;">
-          <p style="margin:0;color:var(--gray);">$ <span style="color:var(--cyan);">mercury start -d</span></p>
+          <p style="margin:0;color:var(--gray);">$ <span style="color:var(--cyan);">mercury up</span></p>
+          <p style="margin:0;color:var(--cyan);">Installing Mercury as a system service...</p>
+          <p style="margin:0;color:var(--green);">Mercury service installed (LaunchAgent)</p>
+          <p style="margin:0;color:var(--cyan);">Starting Mercury in background...</p>
           <p style="margin:0;color:var(--white);">Mercury started in background (PID: 48291)</p>
-          <p style="margin:0;color:var(--gray-dim);">Logs: ~/.mercury/daemon.log</p>
-          <p style="margin:0;color:var(--gray-dim);">Use `mercury stop` to stop.</p>
-          <p style="margin:8px 0 0;color:var(--gray);">$ <span style="color:var(--cyan);">mercury service install</span></p>
-          <p style="margin:0;color:var(--green);">Mercury service installed (macOS LaunchAgent)</p>
           <p style="margin:0;color:var(--gray-dim);">Auto-starts on login. Auto-restarts on crash.</p>
         </div>
       </div>
@@ -416,10 +415,10 @@
         <div class="cap-group" data-reveal>
           <h3>Commands</h3>
           <ul>
-            <li><code>mercury start -d</code> — Background daemon</li>
+            <li><code>mercury up</code> — Install service + start daemon</li>
+            <li><code>mercury start</code> — Foreground mode</li>
+            <li><code>mercury restart</code> — Restart background process</li>
             <li><code>mercury stop</code> — Stop background process</li>
-            <li><code>mercury logs</code> — View daemon logs</li>
-            <li><code>mercury service install</code> — Auto-start on boot</li>
             <li><code>mercury doctor</code> — Reconfigure (Enter keeps values)</li>
             <li><code>/help</code> <code>/status</code> <code>/budget</code> — In-chat commands</li>
           </ul>

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -28,6 +28,14 @@ import type { Scheduler } from '../core/scheduler.js';
 import type { TokenBudget } from '../utils/tokens.js';
 import { logger } from '../utils/logger.js';
 
+export interface ChatCommandContext {
+  toolNames: () => string[];
+  skillNames: () => string[];
+  config: () => import('../utils/config.js').MercuryConfig;
+  tokenBudget: () => import('../utils/tokens.js').TokenBudget;
+  manual: () => string;
+}
+
 export class CapabilityRegistry {
   readonly permissions: PermissionManager;
   private tools: Record<string, Tool> = {};
@@ -37,12 +45,21 @@ export class CapabilityRegistry {
   private sendFileHandler?: (filePath: string) => Promise<void>;
   private currentChannelId = 'cli';
   private currentChannelType = 'cli';
+  private chatCommandContext?: ChatCommandContext;
 
   constructor(skillLoader?: SkillLoader, scheduler?: Scheduler, tokenBudget?: TokenBudget) {
     this.permissions = new PermissionManager();
     this.skillLoader = skillLoader;
     this.scheduler = scheduler;
     this.tokenBudget = tokenBudget;
+  }
+
+  setChatCommandContext(ctx: ChatCommandContext): void {
+    this.chatCommandContext = ctx;
+  }
+
+  getChatCommandContext(): ChatCommandContext | undefined {
+    return this.chatCommandContext;
   }
 
   setChannelContext(channelId: string, channelType: string): void {

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -15,9 +15,14 @@ export class TelegramChannel extends BaseChannel {
   private bot: Bot | null = null;
   private ownerChatId: number | null = null;
   private typingInterval: NodeJS.Timeout | null = null;
+  private chatCommandContext?: import('../capabilities/registry.js').ChatCommandContext;
 
   constructor(private config: MercuryConfig) {
     super();
+  }
+
+  setChatCommandContext(ctx: import('../capabilities/registry.js').ChatCommandContext): void {
+    this.chatCommandContext = ctx;
   }
 
   async start(): Promise<void> {
@@ -57,11 +62,35 @@ export class TelegramChannel extends BaseChannel {
     this.bot = bot;
 
     await bot.start({
-      onStart: (info) => {
+      onStart: async (info) => {
         logger.info({ bot: info.username }, 'Telegram bot started — long polling active');
         this.ready = true;
+        await this.registerCommands();
       },
     });
+  }
+
+  private async registerCommands(): Promise<void> {
+    if (!this.bot) return;
+
+    const commands = [
+      { command: 'help', description: 'Show capabilities and commands manual' },
+      { command: 'status', description: 'Show agent config, budget, and uptime' },
+      { command: 'tools', description: 'List all loaded tools' },
+      { command: 'skills', description: 'List installed skills' },
+      { command: 'budget', description: 'Show token budget status' },
+      { command: 'budget_override', description: 'Override budget for one request' },
+      { command: 'budget_reset', description: 'Reset token usage to zero' },
+      { command: 'budget_set', description: 'Set new daily token budget' },
+      { command: 'stream', description: 'Toggle text streaming on/off' },
+    ];
+
+    try {
+      await this.bot.api.setMyCommands(commands);
+      logger.info({ count: commands.length }, 'Telegram bot commands registered');
+    } catch (err: any) {
+      logger.warn({ err: err.message }, 'Failed to register Telegram commands (non-critical)');
+    }
   }
 
   async stop(): Promise<void> {
@@ -166,23 +195,78 @@ export class TelegramChannel extends BaseChannel {
     }
   }
 
-  async sendStreamToChat(chatId: number, textStream: AsyncIterable<string>): Promise<void> {
-    if (!this.bot) return;
+  async sendStreamToChat(chatId: number, textStream: AsyncIterable<string>): Promise<string> {
+    if (!this.bot) return '';
+
+    const STREAM_EDIT_INTERVAL = 1500;
+    const STREAM_MIN_LENGTH = 20;
+
     this.startTypingLoop(chatId);
+
     try {
       let full = '';
+      let messageId: number | null = null;
+      let lastEditTime = 0;
+      let lastEditLength = 0;
+
       for await (const chunk of textStream) {
         full += chunk;
+
+        const now = Date.now();
+        const timeSinceLastEdit = now - lastEditTime;
+        const charsSinceLastEdit = full.length - lastEditLength;
+
+        if (messageId === null && full.length >= STREAM_MIN_LENGTH) {
+          try {
+            const msg = await this.bot.api.sendMessage(chatId, this.escapeHtml(full) + ' ▌', { parse_mode: 'HTML' });
+            messageId = msg.message_id;
+            lastEditTime = now;
+            lastEditLength = full.length;
+          } catch {
+            messageId = null;
+          }
+        } else if (messageId !== null && timeSinceLastEdit >= STREAM_EDIT_INTERVAL && charsSinceLastEdit >= 20) {
+          try {
+            await this.bot.api.editMessageText(chatId, messageId, this.escapeHtml(full) + ' ▌', { parse_mode: 'HTML' });
+            lastEditTime = now;
+            lastEditLength = full.length;
+          } catch {
+            // edit failed — rate limited or message unchanged, skip
+          }
+        }
       }
-      const html = mdToTelegram(full);
-      try {
-        await this.bot.api.sendMessage(chatId, html, { parse_mode: 'HTML' });
-      } catch {
-        await this.bot.api.sendMessage(chatId, this.stripHtml(html));
+
+      if (messageId !== null) {
+        const html = mdToTelegram(full);
+        try {
+          await this.bot.api.editMessageText(chatId, messageId, html, { parse_mode: 'HTML' });
+        } catch {
+          try {
+            await this.bot.api.editMessageText(chatId, messageId, this.stripHtml(html));
+          } catch {
+            // final edit failed
+          }
+        }
+      } else {
+        const html = mdToTelegram(full);
+        try {
+          await this.bot.api.sendMessage(chatId, html, { parse_mode: 'HTML' });
+        } catch {
+          await this.bot.api.sendMessage(chatId, this.stripHtml(html));
+        }
       }
+
+      return full;
     } finally {
       this.stopTypingLoop();
     }
+  }
+
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   private splitMessage(text: string, maxLen: number): string[] {

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -1,0 +1,122 @@
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, openSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+import chalk from 'chalk';
+import { getMercuryHome } from '../utils/config.js';
+
+const PID_FILE = 'daemon.pid';
+const LOG_FILE = 'daemon.log';
+
+function pidPath(): string {
+  return join(getMercuryHome(), PID_FILE);
+}
+
+function logPath(): string {
+  return join(getMercuryHome(), LOG_FILE);
+}
+
+export function readPid(): number | null {
+  const path = pidPath();
+  if (!existsSync(path)) return null;
+  try {
+    const pid = parseInt(readFileSync(path, 'utf-8').trim(), 10);
+    if (isNaN(pid)) return null;
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getDaemonStatus(): { running: boolean; pid: number | null; logPath: string } {
+  const pid = readPid();
+  if (!pid) return { running: false, pid: null, logPath: logPath() };
+  return { running: isProcessRunning(pid), pid, logPath: logPath() };
+}
+
+export function startBackground(): void {
+  const status = getDaemonStatus();
+  if (status.running && status.pid) {
+    console.log(chalk.yellow(`  Mercury is already running (PID: ${status.pid})`));
+    console.log(chalk.dim(`  Use \`mercury stop\` to stop it first.`));
+    console.log('');
+    process.exit(1);
+  }
+
+  if (status.pid && !status.running) {
+    try { unlinkSync(pidPath()); } catch {}
+  }
+
+  const home = getMercuryHome();
+  if (!existsSync(home)) {
+    mkdirSync(home, { recursive: true });
+  }
+
+  const logFile = logPath();
+  const outFd = openSync(logFile, 'a');
+
+  const child = spawn(process.execPath, [process.argv[1], 'start', '--daemon'], {
+    detached: true,
+    stdio: ['ignore', outFd, outFd],
+    env: { ...process.env },
+  });
+
+  child.unref();
+
+  writeFileSync(pidPath(), String(child.pid));
+
+  console.log('');
+  console.log(chalk.green(`  Mercury started in background (PID: ${child.pid})`));
+  console.log(chalk.dim(`  Logs: ${logFile}`));
+  console.log(chalk.dim(`  Use \`mercury stop\` to stop.`));
+  console.log(chalk.dim(`  Use \`mercury logs\` to view logs.`));
+  console.log('');
+}
+
+export function stopDaemon(): void {
+  const status = getDaemonStatus();
+
+  if (!status.pid) {
+    console.log(chalk.yellow('  Mercury is not running as a daemon.'));
+    console.log('');
+    process.exit(0);
+  }
+
+  if (!status.running) {
+    console.log(chalk.yellow(`  Stale PID file found (PID: ${status.pid} is not running). Cleaning up.`));
+    try { unlinkSync(pidPath()); } catch {}
+    console.log('');
+    process.exit(0);
+  }
+
+  try {
+    process.kill(status.pid, 'SIGTERM');
+    console.log(chalk.green(`  Mercury stopped (PID: ${status.pid})`));
+  } catch {
+    console.log(chalk.red(`  Failed to stop PID ${status.pid}. You may need to kill it manually.`));
+  }
+
+  try { unlinkSync(pidPath()); } catch {}
+  console.log('');
+}
+
+export function showLogs(): void {
+  const logFile = logPath();
+  if (!existsSync(logFile)) {
+    console.log(chalk.dim('  No daemon log file found.'));
+    console.log('');
+    return;
+  }
+  const content = readFileSync(logFile, 'utf-8');
+  const lines = content.split('\n').slice(-100);
+  console.log(lines.join('\n'));
+}

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -62,12 +62,14 @@ export function startBackground(): void {
   }
 
   const logFile = logPath();
+  const isWin = process.platform === 'win32';
   const outFd = openSync(logFile, 'a');
 
   const child = spawn(process.execPath, [process.argv[1], 'start', '--daemon'], {
     detached: true,
     stdio: ['ignore', outFd, outFd],
     env: { ...process.env },
+    windowsHide: isWin,
   });
 
   child.unref();
@@ -99,7 +101,11 @@ export function stopDaemon(): void {
   }
 
   try {
-    process.kill(status.pid, 'SIGTERM');
+    if (process.platform === 'win32') {
+      process.kill(status.pid);
+    } else {
+      process.kill(status.pid, 'SIGTERM');
+    }
     console.log(chalk.green(`  Mercury stopped (PID: ${status.pid})`));
   } catch {
     console.log(chalk.red(`  Failed to stop PID ${status.pid}. You may need to kill it manually.`));

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -150,3 +150,43 @@ export function showLogs(): void {
   const lines = content.split('\n').slice(-100);
   console.log(lines.join('\n'));
 }
+
+export function tryAutoDaemonize(): boolean {
+  try {
+    const status = getDaemonStatus();
+    if (status.running && status.pid) {
+      return true;
+    }
+
+    if (status.pid && !status.running) {
+      try { unlinkSync(pidPath()); } catch {}
+    }
+
+    const home = getMercuryHome();
+    if (!existsSync(home)) {
+      mkdirSync(home, { recursive: true });
+    }
+
+    const logFile = logPath();
+    const isWin = process.platform === 'win32';
+    const outFd = openSync(logFile, 'a');
+
+    const child = spawn(process.execPath, [process.argv[1], 'start', '--daemon'], {
+      detached: true,
+      stdio: ['ignore', outFd, outFd],
+      env: { ...process.env },
+      windowsHide: isWin,
+    });
+
+    child.unref();
+
+    if (!child.pid) {
+      return false;
+    }
+
+    writeFileSync(pidPath(), String(child.pid));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -115,6 +115,30 @@ export function stopDaemon(): void {
   console.log('');
 }
 
+export function restartDaemon(): void {
+  const status = getDaemonStatus();
+
+  if (status.running && status.pid) {
+    console.log(chalk.yellow(`  Stopping Mercury (PID: ${status.pid})...`));
+    try {
+      if (process.platform === 'win32') {
+        process.kill(status.pid);
+      } else {
+        process.kill(status.pid, 'SIGTERM');
+      }
+    } catch {
+      // process may have already exited
+    }
+    try { unlinkSync(pidPath()); } catch {}
+    console.log(chalk.green('  Mercury stopped.'));
+  } else if (status.pid) {
+    try { unlinkSync(pidPath()); } catch {}
+  }
+
+  console.log(chalk.yellow('  Starting Mercury...'));
+  startBackground();
+}
+
 export function showLogs(): void {
   const logFile = logPath();
   if (!existsSync(logFile)) {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -1,0 +1,297 @@
+import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import chalk from 'chalk';
+import { execSync } from 'node:child_process';
+import { getMercuryHome } from '../utils/config.js';
+import { logger } from '../utils/logger.js';
+
+const SERVICE_NAME = 'mercury';
+const SERVICE_DESC = 'Mercury — Soul-Driven AI Agent';
+
+function getNodeBinPath(): string {
+  return process.execPath;
+}
+
+function getDistPath(): string {
+  return join(process.argv[1] || '/usr/local/bin/mercury', '..', '..', 'lib', 'node_modules', '@cosmicstack', 'mercury-agent', 'dist', 'index.js');
+}
+
+export function installService(): void {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    installMac();
+  } else if (platform === 'linux') {
+    installLinux();
+  } else if (platform === 'win32') {
+    console.log(chalk.yellow('  Windows service install is not yet automated.'));
+    console.log(chalk.dim('  Use \`mercury start -d\` for background mode, or install PM2:'));
+    console.log(chalk.dim('    npm i -g pm2'));
+    console.log(chalk.dim('    pm2 start mercury'));
+    console.log(chalk.dim('    pm2 startup'));
+    console.log('');
+    return;
+  } else {
+    console.log(chalk.red(`  Unsupported platform: ${platform}`));
+    process.exit(1);
+  }
+}
+
+export function uninstallService(): void {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    uninstallMac();
+  } else if (platform === 'linux') {
+    uninstallLinux();
+  } else if (platform === 'win32') {
+    console.log(chalk.yellow('  Windows service uninstall is not yet automated.'));
+    console.log('');
+  } else {
+    console.log(chalk.red(`  Unsupported platform: ${platform}`));
+    process.exit(1);
+  }
+}
+
+export function showServiceStatus(): void {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    showMacStatus();
+  } else if (platform === 'linux') {
+    showLinuxStatus();
+  } else if (platform === 'win32') {
+    console.log(chalk.yellow('  Windows service status is not yet automated.'));
+    console.log('');
+  }
+}
+
+function installMac(): void {
+  const plistDir = join(homedir(), 'Library', 'LaunchAgents');
+  const plistPath = join(plistDir, 'com.cosmicstack.mercury.plist');
+
+  if (!existsSync(plistDir)) {
+    mkdirSync(plistDir, { recursive: true });
+  }
+
+  const nodeBin = getNodeBinPath();
+  const scriptPath = getDistPath();
+  const home = getMercuryHome();
+  const logPath = join(home, 'daemon.log');
+  const errPath = join(home, 'daemon-error.log');
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cosmicstack.mercury</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${nodeBin}</string>
+    <string>${scriptPath}</string>
+    <string>start</string>
+    <string>--daemon</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${logPath}</string>
+  <key>StandardErrorPath</key>
+  <string>${errPath}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${process.env.PATH || '/usr/local/bin:/usr/bin:/bin'}</string>
+    <key>HOME</key>
+    <string>${homedir()}</string>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>${homedir()}</string>
+</dict>
+</plist>`;
+
+  writeFileSync(plistPath, plist, 'utf-8');
+
+  try {
+    execSync(`launchctl load ${plistPath}`, { stdio: 'inherit' });
+  } catch {
+    console.log(chalk.yellow('  launchctl load failed. Try running:'));
+    console.log(chalk.dim(`    launchctl load ${plistPath}`));
+  }
+
+  console.log('');
+  console.log(chalk.green('  Mercury service installed (macOS LaunchAgent)'));
+  console.log(chalk.dim(`  Plist: ${plistPath}`));
+  console.log(chalk.dim(`  Logs: ${logPath}`));
+  console.log(chalk.dim('  Auto-starts on login. Auto-restarts on crash.'));
+  console.log('');
+  console.log(chalk.dim('  Uninstall: mercury service uninstall'));
+  console.log('');
+}
+
+function uninstallMac(): void {
+  const plistPath = join(homedir(), 'Library', 'LaunchAgents', 'com.cosmicstack.mercury.plist');
+
+  if (!existsSync(plistPath)) {
+    console.log(chalk.yellow('  Mercury service is not installed.'));
+    console.log('');
+    process.exit(0);
+  }
+
+  try {
+    execSync(`launchctl unload ${plistPath}`, { stdio: 'inherit' });
+  } catch {
+    // may already be unloaded
+  }
+
+  try {
+    unlinkSync(plistPath);
+  } catch {
+    console.log(chalk.yellow('  Failed to remove plist file. Remove manually:'));
+    console.log(chalk.dim(`    rm ${plistPath}`));
+  }
+
+  console.log('');
+  console.log(chalk.green('  Mercury service uninstalled'));
+  console.log('');
+}
+
+function showMacStatus(): void {
+  const plistPath = join(homedir(), 'Library', 'LaunchAgents', 'com.cosmicstack.mercury.plist');
+
+  if (!existsSync(plistPath)) {
+    console.log(chalk.yellow('  Mercury service is not installed.'));
+    console.log(chalk.dim('  Run `mercury service install` to set it up.'));
+    console.log('');
+    return;
+  }
+
+  try {
+    const output = execSync('launchctl list | grep com.cosmicstack.mercury', { encoding: 'utf-8' }).trim();
+    console.log(`  ${chalk.green('Service installed and loaded')}`);
+    console.log(chalk.dim(`  ${output}`));
+  } catch {
+    console.log(`  ${chalk.yellow('Service installed but not loaded')}`);
+    console.log(chalk.dim(`  Plist: ${plistPath}`));
+  }
+  console.log('');
+}
+
+function installLinux(): void {
+  const systemdDir = join(homedir(), '.config', 'systemd', 'user');
+
+  if (!existsSync(systemdDir)) {
+    mkdirSync(systemdDir, { recursive: true });
+  }
+
+  const servicePath = join(systemdDir, 'mercury.service');
+  const nodeBin = getNodeBinPath();
+  const scriptPath = getDistPath();
+  const home = getMercuryHome();
+
+  const service = `[Unit]
+Description=${SERVICE_DESC}
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${nodeBin} ${scriptPath} start --daemon
+Restart=on-failure
+RestartSec=5
+Environment=PATH=${process.env.PATH || '/usr/local/bin:/usr/bin:/bin'}
+Environment=HOME=${homedir()}
+WorkingDirectory=${homedir()}
+StandardOutput=append:${join(home, 'daemon.log')}
+StandardError=append:${join(home, 'daemon-error.log')}
+
+[Install]
+WantedBy=default.target`;
+
+  writeFileSync(servicePath, service, 'utf-8');
+
+  try {
+    execSync('systemctl --user daemon-reload', { stdio: 'inherit' });
+    execSync('systemctl --user enable mercury.service', { stdio: 'inherit' });
+    execSync('systemctl --user start mercury.service', { stdio: 'inherit' });
+  } catch (err) {
+    console.log(chalk.yellow('  systemd commands failed. Try running manually:'));
+    console.log(chalk.dim('    systemctl --user daemon-reload'));
+    console.log(chalk.dim('    systemctl --user enable mercury.service'));
+    console.log(chalk.dim('    systemctl --user start mercury.service'));
+  }
+
+  try {
+    execSync(`loginctl enable-linger ${process.env.USER || ''}`, { stdio: 'inherit' });
+  } catch {
+    console.log(chalk.yellow('  Enable linger failed (needed for boot-without-login). Try:'));
+    console.log(chalk.dim(`    sudo loginctl enable-linger ${process.env.USER || '$USER'}`));
+  }
+
+  console.log('');
+  console.log(chalk.green('  Mercury service installed (systemd --user)'));
+  console.log(chalk.dim(`  Service: ${servicePath}`));
+  console.log(chalk.dim(`  Logs: ${join(home, 'daemon.log')}`));
+  console.log(chalk.dim('  Auto-starts on login. Auto-restarts on crash (5s delay).'));
+  console.log('');
+  console.log(chalk.dim('  Uninstall: mercury service uninstall'));
+  console.log('');
+}
+
+function uninstallLinux(): void {
+  const servicePath = join(homedir(), '.config', 'systemd', 'user', 'mercury.service');
+
+  if (!existsSync(servicePath)) {
+    console.log(chalk.yellow('  Mercury service is not installed.'));
+    console.log('');
+    process.exit(0);
+  }
+
+  try {
+    execSync('systemctl --user stop mercury.service', { stdio: 'inherit' });
+    execSync('systemctl --user disable mercury.service', { stdio: 'inherit' });
+  } catch {
+    // may already be stopped
+  }
+
+  try {
+    unlinkSync(servicePath);
+  } catch {
+    console.log(chalk.yellow('  Failed to remove service file. Remove manually:'));
+    console.log(chalk.dim(`    rm ${servicePath}`));
+  }
+
+  try {
+    execSync('systemctl --user daemon-reload', { stdio: 'inherit' });
+  } catch {}
+
+  console.log('');
+  console.log(chalk.green('  Mercury service uninstalled'));
+  console.log('');
+}
+
+function showLinuxStatus(): void {
+  const servicePath = join(homedir(), '.config', 'systemd', 'user', 'mercury.service');
+
+  if (!existsSync(servicePath)) {
+    console.log(chalk.yellow('  Mercury service is not installed.'));
+    console.log(chalk.dim('  Run `mercury service install` to set it up.'));
+    console.log('');
+    return;
+  }
+
+  try {
+    const output = execSync('systemctl --user status mercury.service', { encoding: 'utf-8' }).trim();
+    console.log(output);
+  } catch (err: any) {
+    console.log(chalk.yellow('  Could not get service status:'));
+    console.log(chalk.dim(`  ${err.message || err}`));
+  }
+  console.log('');
+}

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -25,13 +25,7 @@ export function installService(): void {
   } else if (platform === 'linux') {
     installLinux();
   } else if (platform === 'win32') {
-    console.log(chalk.yellow('  Windows service install is not yet automated.'));
-    console.log(chalk.dim('  Use \`mercury start -d\` for background mode, or install PM2:'));
-    console.log(chalk.dim('    npm i -g pm2'));
-    console.log(chalk.dim('    pm2 start mercury'));
-    console.log(chalk.dim('    pm2 startup'));
-    console.log('');
-    return;
+    installWindows();
   } else {
     console.log(chalk.red(`  Unsupported platform: ${platform}`));
     process.exit(1);
@@ -46,8 +40,7 @@ export function uninstallService(): void {
   } else if (platform === 'linux') {
     uninstallLinux();
   } else if (platform === 'win32') {
-    console.log(chalk.yellow('  Windows service uninstall is not yet automated.'));
-    console.log('');
+    uninstallWindows();
   } else {
     console.log(chalk.red(`  Unsupported platform: ${platform}`));
     process.exit(1);
@@ -62,8 +55,7 @@ export function showServiceStatus(): void {
   } else if (platform === 'linux') {
     showLinuxStatus();
   } else if (platform === 'win32') {
-    console.log(chalk.yellow('  Windows service status is not yet automated.'));
-    console.log('');
+    showWindowsStatus();
   }
 }
 
@@ -294,4 +286,69 @@ function showLinuxStatus(): void {
     console.log(chalk.dim(`  ${err.message || err}`));
   }
   console.log('');
+}
+
+const WIN_TASK_NAME = 'MercuryAgent';
+
+function installWindows(): void {
+  const nodeBin = getNodeBinPath();
+  const scriptPath = getDistPath();
+  const home = getMercuryHome();
+  const logPath = join(home, 'daemon.log');
+
+  const cmd = `"${nodeBin}" "${scriptPath}" start --daemon`;
+
+  try {
+    execSync(
+      `schtasks /create /tn "${WIN_TASK_NAME}" /tr "${cmd}" /sc onlogon /rl limited /f`,
+      { stdio: 'inherit', shell: 'cmd.exe' }
+    );
+  } catch {
+    console.log(chalk.yellow('  schtasks create failed. Try running from an Administrator cmd:'));
+    console.log(chalk.dim(`    schtasks /create /tn "${WIN_TASK_NAME}" /tr "${cmd}" /sc onlogon /rl limited /f`));
+  }
+
+  try {
+    execSync(`schtasks /run /tn "${WIN_TASK_NAME}"`, { stdio: 'inherit', shell: 'cmd.exe' });
+  } catch {
+    console.log(chalk.yellow('  Task created but failed to start immediately. It will start on next login.'));
+  }
+
+  console.log('');
+  console.log(chalk.green('  Mercury service installed (Windows Task Scheduler)'));
+  console.log(chalk.dim(`  Task: ${WIN_TASK_NAME}`));
+  console.log(chalk.dim(`  Trigger: on logon`));
+  console.log(chalk.dim(`  Logs: ${logPath}`));
+  console.log(chalk.dim('  Auto-starts on login. Use --daemon flag for crash recovery.'));
+  console.log('');
+  console.log(chalk.dim('  Uninstall: mercury service uninstall'));
+  console.log('');
+}
+
+function uninstallWindows(): void {
+  try {
+    execSync(`schtasks /delete /tn "${WIN_TASK_NAME}" /f`, { stdio: 'inherit', shell: 'cmd.exe' });
+    console.log('');
+    console.log(chalk.green('  Mercury service uninstalled'));
+    console.log('');
+  } catch {
+    console.log(chalk.yellow('  Task not found or failed to delete. Remove manually:'));
+    console.log(chalk.dim(`    schtasks /delete /tn "${WIN_TASK_NAME}" /f`));
+    console.log('');
+  }
+}
+
+function showWindowsStatus(): void {
+  try {
+    const output = execSync(`schtasks /query /tn "${WIN_TASK_NAME}" /fo list`, {
+      encoding: 'utf-8',
+      shell: 'cmd.exe',
+    }).trim();
+    console.log(output);
+    console.log('');
+  } catch {
+    console.log(chalk.yellow('  Mercury service is not installed.'));
+    console.log(chalk.dim('  Run `mercury service install` to set it up.'));
+    console.log('');
+  }
 }

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -8,6 +8,25 @@ import { logger } from '../utils/logger.js';
 
 const SERVICE_NAME = 'mercury';
 const SERVICE_DESC = 'Mercury — Soul-Driven AI Agent';
+const WIN_TASK_NAME = 'MercuryAgent';
+
+export function isServiceInstalled(): boolean {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    return existsSync(join(homedir(), 'Library', 'LaunchAgents', 'com.cosmicstack.mercury.plist'));
+  } else if (platform === 'linux') {
+    return existsSync(join(homedir(), '.config', 'systemd', 'user', 'mercury.service'));
+  } else if (platform === 'win32') {
+    try {
+      execSync(`schtasks /query /tn "${WIN_TASK_NAME}"`, { stdio: 'pipe', shell: 'cmd.exe' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
 
 function getNodeBinPath(): string {
   return process.execPath;
@@ -287,8 +306,6 @@ function showLinuxStatus(): void {
   }
   console.log('');
 }
-
-const WIN_TASK_NAME = 'MercuryAgent';
 
 function installWindows(): void {
   const nodeBin = getNodeBinPath();

--- a/src/cli/watchdog.ts
+++ b/src/cli/watchdog.ts
@@ -1,0 +1,36 @@
+import { logger } from '../utils/logger.js';
+
+const MAX_RESTARTS = 10;
+const RESTART_WINDOW_MS = 60_000;
+const BASE_DELAY_MS = 1_000;
+
+export async function runWithWatchdog(agentFn: () => Promise<void>): Promise<void> {
+  const restarts: number[] = [];
+
+  async function attempt(): Promise<void> {
+    try {
+      await agentFn();
+    } catch (err) {
+      const now = Date.now();
+      restarts.push(now);
+      const recentRestarts = restarts.filter(t => now - t < RESTART_WINDOW_MS);
+      const restartCount = recentRestarts.length;
+
+      if (restartCount >= MAX_RESTARTS) {
+        logger.error({ restartCount }, 'Max restarts exceeded within 60s. Exiting.');
+        process.exit(1);
+      }
+
+      const delay = BASE_DELAY_MS * Math.pow(1.25, restartCount);
+      logger.warn({ err, restartCount, delay }, 'Crash detected. Restarting with backoff...');
+      await sleep(delay);
+      await attempt();
+    }
+  }
+
+  await attempt();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -118,6 +118,11 @@ export class Agent {
         return;
       }
 
+      if (await this.handleChatCommand(trimmed, msg.channelType, msg.channelId)) {
+        this.lifecycle.transition('idle');
+        return;
+      }
+
       if (this.tokenBudget.isOverBudget()) {
         const channel = this.channels.getChannelForMessage(msg);
         if (channel && msg.channelType !== 'internal') {
@@ -489,5 +494,62 @@ export class Agent {
     } else {
       await channel.send(`Unknown budget command "${action}". Available: /budget, /budget override, /budget reset, /budget set <number>, /budget status`, channelId);
     }
+  }
+
+  private async handleChatCommand(content: string, channelType: string, channelId: string): Promise<boolean> {
+    const cmd = content.toLowerCase().trim();
+    const channel = this.channels.get(channelType as any);
+    if (!channel) return false;
+
+    const ctx = this.capabilities.getChatCommandContext();
+    if (!ctx) return false;
+
+    if (cmd === '/help') {
+      await channel.send(ctx.manual(), channelId);
+      return true;
+    }
+
+    if (cmd === '/status') {
+      const config = ctx.config();
+      const budget = ctx.tokenBudget();
+      const lines = [
+        `**${config.identity.name}** — Status`,
+        `Owner: ${config.identity.owner || '(not set)'}`,
+        `Provider: ${config.providers.default}`,
+        `Telegram: ${config.channels.telegram.enabled ? 'enabled' : 'disabled'}`,
+        `Budget: ${budget.getStatusText()}`,
+        `Skills: ${ctx.skillNames().length > 0 ? ctx.skillNames().join(', ') : 'none'}`,
+      ];
+      await channel.send(lines.join('\n'), channelId);
+      return true;
+    }
+
+    if (cmd === '/tools') {
+      const tools = ctx.toolNames();
+      const grouped = [
+        `**${tools.length} tools loaded:**`,
+        '',
+        ...tools.sort().map(t => `• \`${t}\``),
+      ];
+      await channel.send(grouped.join('\n'), channelId);
+      return true;
+    }
+
+    if (cmd === '/skills') {
+      const names = ctx.skillNames();
+      if (names.length === 0) {
+        await channel.send('No skills installed. Ask me to "install skill from <url>" to add one.', channelId);
+      } else {
+        const lines = [
+          `**${names.length} skill${names.length > 1 ? 's' : ''} installed:**`,
+          '',
+          ...names.map(n => `• ${n}`),
+        ];
+        await channel.send(lines.join('\n'), channelId);
+      }
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -21,6 +21,7 @@ export class Agent {
   private running = false;
   private messageQueue: ChannelMessage[] = [];
   private processing = false;
+  private telegramStreaming: boolean;
 
   constructor(
     private config: MercuryConfig,
@@ -37,6 +38,7 @@ export class Agent {
     this.lifecycle = new Lifecycle();
     this.scheduler = scheduler;
     this.capabilities = capabilities;
+    this.telegramStreaming = config.channels.telegram.streaming ?? true;
 
     this.scheduler.setOnScheduledTask(async (manifest) => this.handleScheduledTask(manifest));
 
@@ -118,6 +120,37 @@ export class Agent {
         return;
       }
 
+      if (trimmed === '/budget_override') {
+        await this.handleBudgetCommand('override', msg.channelType, msg.channelId);
+        this.lifecycle.transition('idle');
+        return;
+      }
+      if (trimmed === '/budget_reset') {
+        await this.handleBudgetCommand('reset', msg.channelType, msg.channelId);
+        this.lifecycle.transition('idle');
+        return;
+      }
+      if (trimmed.startsWith('/budget_set')) {
+        const args = trimmed.slice('/budget_set'.length).trim();
+        await this.handleBudgetCommand('set ' + args, msg.channelType, msg.channelId);
+        this.lifecycle.transition('idle');
+        return;
+      }
+      if (trimmed.startsWith('/stream')) {
+        const sub = trimmed.slice('/stream'.length).trim().toLowerCase();
+        if (sub === 'off') {
+          this.telegramStreaming = false;
+          const ch = this.channels.get(msg.channelType as any);
+          if (ch) await ch.send('Telegram streaming disabled. Responses will arrive as a single message.', msg.channelId);
+        } else {
+          this.telegramStreaming = true;
+          const ch = this.channels.get(msg.channelType as any);
+          if (ch) await ch.send('Telegram streaming enabled. Responses will appear progressively.', msg.channelId);
+        }
+        this.lifecycle.transition('idle');
+        return;
+      }
+
       if (await this.handleChatCommand(trimmed, msg.channelType, msg.channelId)) {
         this.lifecycle.transition('idle');
         return;
@@ -184,7 +217,7 @@ export class Agent {
       let lastError: any = null;
       let streamedText = '';
 
-      const canStream = msg.channelType === 'cli';
+      const canStream = msg.channelType === 'cli' || (msg.channelType === 'telegram' && this.telegramStreaming);
 
       for (const provider of fallbackIterator) {
         try {
@@ -206,7 +239,25 @@ export class Agent {
               },
             });
 
-            const fullText = await channel.stream(streamResult.textStream, msg.channelId);
+            let fullText: string;
+
+            if (msg.channelType === 'telegram') {
+              const tgChannel = this.channels.get('telegram');
+              if (tgChannel && 'sendStreamToChat' in tgChannel) {
+                const chatId = msg.channelId.startsWith('telegram:')
+                  ? Number(msg.channelId.split(':')[1])
+                  : Number(msg.channelId);
+                if (!isNaN(chatId)) {
+                  fullText = await (tgChannel as any).sendStreamToChat(chatId, streamResult.textStream);
+                } else {
+                  fullText = await channel.stream(streamResult.textStream, msg.channelId);
+                }
+              } else {
+                fullText = await channel.stream(streamResult.textStream, msg.channelId);
+              }
+            } else {
+              fullText = await channel.stream(streamResult.textStream, msg.channelId);
+            }
 
             const [usage] = await Promise.all([
               streamResult.usage,
@@ -547,6 +598,18 @@ export class Agent {
         ];
         await channel.send(lines.join('\n'), channelId);
       }
+      return true;
+    }
+
+    if (cmd === '/stream' || cmd === '/stream on') {
+      this.telegramStreaming = true;
+      await channel.send('Telegram streaming enabled. Responses will appear progressively.', channelId);
+      return true;
+    }
+
+    if (cmd === '/stream off') {
+      this.telegramStreaming = false;
+      await channel.send('Telegram streaming disabled. Responses will arrive as a single message.', channelId);
       return true;
     }
 

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -140,13 +140,18 @@ export class Agent {
         const sub = trimmed.slice('/stream'.length).trim().toLowerCase();
         if (sub === 'off') {
           this.telegramStreaming = false;
-          const ch = this.channels.get(msg.channelType as any);
-          if (ch) await ch.send('Telegram streaming disabled. Responses will arrive as a single message.', msg.channelId);
-        } else {
+        } else if (sub === 'on') {
           this.telegramStreaming = true;
-          const ch = this.channels.get(msg.channelType as any);
-          if (ch) await ch.send('Telegram streaming enabled. Responses will appear progressively.', msg.channelId);
+        } else {
+          this.telegramStreaming = !this.telegramStreaming;
         }
+        const ch = this.channels.get(msg.channelType as any);
+        if (ch) await ch.send(
+          this.telegramStreaming
+            ? 'Telegram streaming enabled. Responses will appear progressively.'
+            : 'Telegram streaming disabled. Responses will arrive as a single message.',
+          msg.channelId,
+        );
         this.lifecycle.transition('idle');
         return;
       }
@@ -601,12 +606,28 @@ export class Agent {
       return true;
     }
 
-    if (cmd === '/stream' || cmd === '/stream on') {
+    if (cmd === '/stream on') {
       this.telegramStreaming = true;
       await channel.send('Telegram streaming enabled. Responses will appear progressively.', channelId);
       return true;
     }
 
+    if (cmd === '/stream off') {
+      this.telegramStreaming = false;
+      await channel.send('Telegram streaming disabled. Responses will arrive as a single message.', channelId);
+      return true;
+    }
+
+    if (cmd === '/stream') {
+      this.telegramStreaming = !this.telegramStreaming;
+      await channel.send(
+        this.telegramStreaming
+          ? 'Telegram streaming enabled. Responses will appear progressively.'
+          : 'Telegram streaming disabled. Responses will arrive as a single message.',
+        channelId,
+      );
+      return true;
+    }
     if (cmd === '/stream off') {
       this.telegramStreaming = false;
       await channel.send('Telegram streaming disabled. Responses will arrive as a single message.', channelId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import readline from 'node:readline';
 import chalk from 'chalk';
 import figlet from 'figlet';
 import { loadConfig, saveConfig, isSetupComplete, getMercuryHome, ensureCreatorField } from './utils/config.js';
+import type { MercuryConfig } from './utils/config.js';
 import { logger } from './utils/logger.js';
 import { Identity } from './soul/identity.js';
 import { ShortTermMemory, LongTermMemory, EpisodicMemory } from './memory/store.js';
@@ -14,6 +15,10 @@ import { CLIChannel } from './channels/cli.js';
 import { TokenBudget } from './utils/tokens.js';
 import { CapabilityRegistry } from './capabilities/registry.js';
 import { SkillLoader } from './skills/loader.js';
+import { getManual } from './utils/manual.js';
+import { startBackground, stopDaemon, showLogs, getDaemonStatus } from './cli/daemon.js';
+import { installService, uninstallService, showServiceStatus } from './cli/service.js';
+import { runWithWatchdog } from './cli/watchdog.js';
 
 function hr() {
   console.log(chalk.dim('─'.repeat(50)));
@@ -54,59 +59,114 @@ async function ask(prompt: string): Promise<string> {
   });
 }
 
-async function onboarding(): Promise<void> {
-  splashScreen();
-  console.log(chalk.yellow('  First run detected — let\'s set you up.'));
-  hr();
-  console.log('');
+function maskKey(key: string): string {
+  if (!key) return '';
+  if (key.length <= 8) return '••••••••';
+  return key.slice(0, 4) + '••••' + key.slice(-4);
+}
 
-  const config = loadConfig();
+async function configure(existingConfig?: MercuryConfig): Promise<void> {
+  const isReconfig = !!existingConfig;
+  const config = existingConfig ?? loadConfig();
 
-  const ownerName = await ask(chalk.white('  Your name: '));
-  if (!ownerName) {
-    console.log(chalk.red('  Name is required.'));
-    process.exit(1);
+  if (isReconfig) {
+    banner();
+    console.log(chalk.yellow('  Reconfiguring Mercury — press Enter to keep current value.'));
+  } else {
+    splashScreen();
+    console.log(chalk.yellow('  First run detected — let\'s set you up.'));
   }
-  config.identity.owner = ownerName;
-
-  const agentName = await ask(chalk.white(`  Agent name [${config.identity.name}]: `));
-  if (agentName) config.identity.name = agentName;
-
-  config.identity.creator = 'Cosmic Stack';
 
   hr();
   console.log('');
-  console.log(chalk.white('  LLM Providers'));
-  console.log(chalk.dim('  At least one API key is required.'));
+  console.log(chalk.bold.white('  Identity'));
   console.log('');
 
-  const deepseekKey = await ask(chalk.white('  DeepSeek API key: '));
+  if (isReconfig) {
+    const ownerName = await ask(chalk.white(`  Your name [${config.identity.owner}]: `));
+    if (ownerName) config.identity.owner = ownerName;
+
+    const agentName = await ask(chalk.white(`  Agent name [${config.identity.name}]: `));
+    if (agentName) config.identity.name = agentName;
+  } else {
+    const ownerName = await ask(chalk.white('  Your name: '));
+    if (!ownerName) {
+      console.log(chalk.red('  Name is required.'));
+      process.exit(1);
+    }
+    config.identity.owner = ownerName;
+
+    const agentName = await ask(chalk.white(`  Agent name [${config.identity.name}]: `));
+    if (agentName) config.identity.name = agentName;
+  }
+
+  config.identity.creator = config.identity.creator || 'Cosmic Stack';
+
+  hr();
+  console.log('');
+  console.log(chalk.bold.white('  LLM Providers'));
+  if (isReconfig) {
+    console.log(chalk.dim('  Current keys shown masked. Enter new value to change, Enter to keep.'));
+  } else {
+    console.log(chalk.dim('  At least one API key is required.'));
+  }
+  console.log('');
+
+  const dsMask = isReconfig && config.providers.deepseek.apiKey ? ` [${maskKey(config.providers.deepseek.apiKey)}]` : '';
+  const deepseekKey = await ask(chalk.white(`  DeepSeek API key${dsMask}: `));
   if (deepseekKey) {
     config.providers.deepseek.apiKey = deepseekKey;
     config.providers.default = 'deepseek';
   }
 
-  const openaiKey = await ask(chalk.white('  OpenAI API key (Enter to skip): '));
+  const oaiMask = isReconfig && config.providers.openai.apiKey ? ` [${maskKey(config.providers.openai.apiKey)}]` : ' (Enter to skip)';
+  const openaiKey = await ask(chalk.white(`  OpenAI API key${oaiMask}: `));
   if (openaiKey) config.providers.openai.apiKey = openaiKey;
 
-  const anthropicKey = await ask(chalk.white('  Anthropic API key (Enter to skip): '));
+  const antMask = isReconfig && config.providers.anthropic.apiKey ? ` [${maskKey(config.providers.anthropic.apiKey)}]` : ' (Enter to skip)';
+  const anthropicKey = await ask(chalk.white(`  Anthropic API key${antMask}: `));
   if (anthropicKey) config.providers.anthropic.apiKey = anthropicKey;
 
-  if (!deepseekKey && !openaiKey && !anthropicKey) {
+  const hasKey = config.providers.deepseek.apiKey || config.providers.openai.apiKey || config.providers.anthropic.apiKey;
+  if (!hasKey) {
     console.log(chalk.red('\n  At least one LLM API key is required.'));
     process.exit(1);
   }
 
   hr();
   console.log('');
-  console.log(chalk.white('  Telegram (optional)'));
-  console.log(chalk.dim('  Leave empty to skip. You can add it later.'));
+  console.log(chalk.bold.white('  Telegram (optional)'));
+  if (isReconfig) {
+    console.log(chalk.dim('  Leave empty to keep current value. Enter "none" to disable.'));
+  } else {
+    console.log(chalk.dim('  Leave empty to skip. You can add it later.'));
+  }
   console.log('');
 
-  const telegramToken = await ask(chalk.white('  Telegram Bot Token: '));
-  if (telegramToken) {
+  const tgMask = isReconfig && config.channels.telegram.botToken ? ` [${maskKey(config.channels.telegram.botToken)}]` : '';
+  const telegramToken = await ask(chalk.white(`  Telegram Bot Token${tgMask}: `));
+  if (isReconfig && telegramToken.toLowerCase() === 'none') {
+    config.channels.telegram.enabled = false;
+    config.channels.telegram.botToken = '';
+  } else if (telegramToken) {
     config.channels.telegram.botToken = telegramToken;
     config.channels.telegram.enabled = true;
+  }
+
+  hr();
+  console.log('');
+  console.log(chalk.bold.white('  Token Budget'));
+  console.log('');
+
+  const budgetPrompt = isReconfig
+    ? chalk.white(`  Daily token budget [${config.tokens.dailyBudget.toLocaleString()}]: `)
+    : chalk.white(`  Daily token budget [${config.tokens.dailyBudget.toLocaleString()}]: `);
+  const budgetStr = await ask(budgetPrompt);
+  if (budgetStr) {
+    const budget = parseInt(budgetStr.replace(/,/g, ''), 10);
+    if (!isNaN(budget) && budget > 0) {
+      config.tokens.dailyBudget = budget;
+    }
   }
 
   hr();
@@ -125,29 +185,43 @@ async function onboarding(): Promise<void> {
   console.log('');
 }
 
-async function runAgent(): Promise<void> {
+async function runAgent(isDaemon: boolean = false): Promise<void> {
   let config = loadConfig();
   config = ensureCreatorField(config);
   const name = config.identity.name;
 
-  banner();
-  console.log(chalk.white(`  ${name} is waking up...`));
-  console.log('');
+  if (!isDaemon) {
+    banner();
+    console.log(chalk.white(`  ${name} is waking up...`));
+    console.log('');
+  } else {
+    logger.info(`${name} is waking up (daemon mode)...`);
+  }
 
   const tokenBudget = new TokenBudget(config);
   const providers = new ProviderRegistry(config);
 
   if (!providers.hasProviders()) {
-    console.log(chalk.red('  No LLM providers available. Run `mercury setup` to configure API keys.'));
+    if (isDaemon) {
+      logger.error('No LLM providers available. Run `mercury doctor` to configure API keys.');
+      return;
+    }
+    console.log(chalk.red('  No LLM providers available. Run `mercury doctor` to configure API keys.'));
     process.exit(1);
   }
 
   const available = providers.listAvailable();
-  console.log(chalk.dim(`  Providers: ${available.join(', ')}`));
+  if (!isDaemon) {
+    console.log(chalk.dim(`  Providers: ${available.join(', ')}`));
+  } else {
+    logger.info({ providers: available }, 'Providers loaded');
+  }
 
   const skillLoader = new SkillLoader();
   const skills = skillLoader.discover();
-  console.log(chalk.dim(`  Skills: ${skills.length > 0 ? skills.map(s => s.name).join(', ') : 'none installed'}`));
+  if (!isDaemon) {
+    console.log(chalk.dim(`  Skills: ${skills.length > 0 ? skills.map(s => s.name).join(', ') : 'none installed'}`));
+  }
 
   const scheduler = new Scheduler(config);
 
@@ -158,6 +232,14 @@ async function runAgent(): Promise<void> {
 
   const channels = new ChannelRegistry(config);
   const capabilities = new CapabilityRegistry(skillLoader, scheduler, tokenBudget);
+
+  capabilities.setChatCommandContext({
+    toolNames: () => capabilities.getToolNames(),
+    skillNames: () => skills.map(s => s.name),
+    config: () => config,
+    tokenBudget: () => tokenBudget,
+    manual: () => getManual(),
+  });
 
   capabilities.setSendFileHandler(async (filePath: string) => {
     const msg = channels.getActiveChannels().includes('telegram')
@@ -187,22 +269,31 @@ async function runAgent(): Promise<void> {
 
   const activeCh = channels.getActiveChannels();
   const toolNames = capabilities.getToolNames();
-  console.log(chalk.dim(`  Channels: ${activeCh.join(', ')}`));
-  console.log(chalk.dim(`  Tools: ${toolNames.join(', ')}`));
-  console.log(chalk.dim(`  Permissions: ${getMercuryHome()}/permissions.yaml`));
-  console.log(chalk.dim(`  Schedules: ${getMercuryHome()}/schedules.yaml`));
-  if (config.identity.creator) {
-    console.log(chalk.dim(`  Creator: ${config.identity.creator}`));
+
+  if (!isDaemon) {
+    console.log(chalk.dim(`  Channels: ${activeCh.join(', ')}`));
+    console.log(chalk.dim(`  Tools: ${toolNames.join(', ')}`));
+    console.log(chalk.dim(`  Permissions: ${getMercuryHome()}/permissions.yaml`));
+    console.log(chalk.dim(`  Schedules: ${getMercuryHome()}/schedules.yaml`));
+    if (config.identity.creator) {
+      console.log(chalk.dim(`  Creator: ${config.identity.creator}`));
+    }
+    hr();
+    console.log('');
+    console.log(chalk.green(`  ${name} is live. Type a message and press Enter.`));
+    console.log(chalk.dim('  Ctrl+C to exit · /help for commands'));
+    console.log('');
+  } else {
+    logger.info({ channels: activeCh, tools: toolNames }, 'Mercury is live (daemon mode)');
   }
-  hr();
-  console.log('');
-  console.log(chalk.green(`  ${name} is live. Type a message and press Enter.`));
-  console.log(chalk.dim('  Ctrl+C to exit.'));
-  console.log('');
 
   const shutdown = async () => {
-    console.log('');
-    console.log(chalk.dim(`  ${name} is shutting down...`));
+    if (!isDaemon) {
+      console.log('');
+      console.log(chalk.dim(`  ${name} is shutting down...`));
+    } else {
+      logger.info('Mercury is shutting down (daemon mode)');
+    }
     await agent.shutdown();
     process.exit(0);
   };
@@ -215,12 +306,12 @@ const program = new Command();
 
 program
   .name('mercury')
-  .description('Mercury — an AI agent for personal tasks')
+  .description('Mercury — Soul-driven AI agent with permission-hardened tools, token budgets, and multi-channel access.')
   .version('0.1.0')
   .option('-v, --verbose', 'Show debug logs')
   .action(async () => {
     if (!isSetupComplete()) {
-      await onboarding();
+      await configure();
       return;
     }
     await runAgent();
@@ -230,29 +321,71 @@ program
   .command('start')
   .description('Start Mercury agent')
   .option('-v, --verbose', 'Show debug logs')
-  .action(async () => {
+  .option('-d, --detached', 'Run in background (daemon mode)')
+  .option('--daemon', 'Internal flag for daemon child process')
+  .action(async (opts) => {
+    if (opts.daemon) {
+      await runWithWatchdog(() => runAgent(true));
+      return;
+    }
+
+    if (opts.detached) {
+      startBackground();
+      return;
+    }
+
     if (!isSetupComplete()) {
-      await onboarding();
+      await configure();
       return;
     }
     await runAgent();
   });
 
 program
+  .command('stop')
+  .description('Stop a background Mercury process')
+  .action(() => {
+    stopDaemon();
+  });
+
+program
+  .command('logs')
+  .description('Show recent daemon logs')
+  .action(() => {
+    showLogs();
+  });
+
+program
   .command('setup')
-  .description('Re-run the setup wizard')
+  .description('Re-run the setup wizard (reconfigure)')
   .action(async () => {
-    await onboarding();
+    if (isSetupComplete()) {
+      await configure(loadConfig());
+    } else {
+      await configure();
+    }
+  });
+
+program
+  .command('doctor')
+  .description('Reconfigure Mercury — change keys, name, settings (Enter to keep current)')
+  .action(async () => {
+    if (isSetupComplete()) {
+      await configure(loadConfig());
+    } else {
+      await configure();
+    }
   });
 
 program
   .command('status')
-  .description('Show current configuration')
+  .description('Show current configuration and daemon status')
   .action(() => {
     const config = loadConfig();
     const home = getMercuryHome();
     const skillLoader = new SkillLoader();
     const skills = skillLoader.discover();
+    const daemon = getDaemonStatus();
     banner();
     console.log(`  Name:     ${chalk.cyan(config.identity.name)}`);
     console.log(`  Owner:    ${chalk.white(config.identity.owner || '(not set)')}`);
@@ -262,10 +395,43 @@ program
     console.log(`  Provider: ${chalk.white(config.providers.default)}`);
     console.log(`  Telegram: ${config.channels.telegram.enabled ? chalk.green('enabled') : chalk.dim('disabled')}`);
     console.log(`  Skills:   ${skills.length > 0 ? chalk.green(skills.map(s => s.name).join(', ')) : chalk.dim('none')}`);
-    console.log(`  Budget:   ${chalk.white(config.tokens.dailyBudget)} tokens/day`);
+    console.log(`  Budget:   ${chalk.white(config.tokens.dailyBudget.toLocaleString())} tokens/day`);
     console.log(`  Setup:    ${isSetupComplete() ? chalk.green('complete') : chalk.red('not done')}`);
+    console.log(`  Daemon:   ${daemon.running ? chalk.green(`running (PID: ${daemon.pid})`) : chalk.dim('not running')}`);
     console.log(`  Home:     ${chalk.dim(home)}`);
     console.log('');
+  });
+
+program
+  .command('help')
+  .description('Show capabilities and commands manual')
+  .action(() => {
+    console.log(getManual());
+  });
+
+const serviceCmd = program
+  .command('service')
+  .description('Manage Mercury as a system service (auto-start, crash recovery)');
+
+serviceCmd
+  .command('install')
+  .description('Install Mercury as a system service (auto-start on boot)')
+  .action(() => {
+    installService();
+  });
+
+serviceCmd
+  .command('uninstall')
+  .description('Uninstall the system service')
+  .action(() => {
+    uninstallService();
+  });
+
+serviceCmd
+  .command('status')
+  .description('Show system service status')
+  .action(() => {
+    showServiceStatus();
   });
 
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { TokenBudget } from './utils/tokens.js';
 import { CapabilityRegistry } from './capabilities/registry.js';
 import { SkillLoader } from './skills/loader.js';
 import { getManual } from './utils/manual.js';
-import { startBackground, stopDaemon, showLogs, getDaemonStatus, restartDaemon } from './cli/daemon.js';
+import { startBackground, stopDaemon, showLogs, getDaemonStatus, restartDaemon, tryAutoDaemonize } from './cli/daemon.js';
 import { installService, uninstallService, showServiceStatus, isServiceInstalled } from './cli/service.js';
 import { runWithWatchdog } from './cli/watchdog.js';
 
@@ -180,8 +180,36 @@ async function configure(existingConfig?: MercuryConfig): Promise<void> {
   console.log(chalk.green(`  ✓ Permissions seeded in ${home}/permissions.yaml`));
   console.log(chalk.green(`  ✓ Skills directory ready in ${home}/skills/`));
   console.log('');
-  console.log(chalk.cyan(`  ${config.identity.name} is ready. Run \`mercury start\` to begin.`));
+  console.log(chalk.cyan(`  ${config.identity.name} is ready. Run \`mercury start\` to chat.`));
   console.log(chalk.dim('  mercury.cosmicstack.org'));
+  console.log('');
+}
+
+function autoDaemonize(): void {
+  const daemon = getDaemonStatus();
+  if (daemon.running) {
+    return;
+  }
+
+  console.log(chalk.dim('  Setting up background mode...'));
+
+  try {
+    if (!isServiceInstalled()) {
+      installService();
+    }
+  } catch {
+    console.log(chalk.dim('  Service install skipped (can run `mercury service install` later).'));
+  }
+
+  const ok = tryAutoDaemonize();
+  if (ok) {
+    const status = getDaemonStatus();
+    console.log(chalk.green(`  ✓ Mercury is running in background (PID: ${status.pid})`));
+    console.log(chalk.green('  ✓ Auto-starts on login. Auto-restarts on crash.'));
+    console.log(chalk.dim('  Use `mercury stop` to stop. `mercury restart` to restart.'));
+  } else {
+    console.log(chalk.dim('  Background mode not available. Run `mercury up` to set it up.'));
+  }
   console.log('');
 }
 
@@ -312,6 +340,7 @@ program
   .action(async () => {
     if (!isSetupComplete()) {
       await configure();
+      autoDaemonize();
       return;
     }
     await runAgent();

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,6 @@ async function configure(existingConfig?: MercuryConfig): Promise<void> {
   const deepseekKey = await ask(chalk.white(`  DeepSeek API key${dsMask}: `));
   if (deepseekKey) {
     config.providers.deepseek.apiKey = deepseekKey;
-    config.providers.default = 'deepseek';
   }
 
   const oaiMask = isReconfig && config.providers.openai.apiKey ? ` [${maskKey(config.providers.openai.apiKey)}]` : ' (Enter to skip)';
@@ -132,6 +131,31 @@ async function configure(existingConfig?: MercuryConfig): Promise<void> {
   if (!hasKey) {
     console.log(chalk.red('\n  At least one LLM API key is required.'));
     process.exit(1);
+  }
+
+  const availableProviders: string[] = [];
+  if (config.providers.deepseek.apiKey) availableProviders.push('deepseek');
+  if (config.providers.openai.apiKey) availableProviders.push('openai');
+  if (config.providers.anthropic.apiKey) availableProviders.push('anthropic');
+
+  if (isReconfig && availableProviders.length > 1) {
+    console.log('');
+    console.log(chalk.bold.white('  Default Provider'));
+    console.log(chalk.dim('  Select the default LLM provider (the one used first).'));
+    console.log('');
+    for (let i = 0; i < availableProviders.length; i++) {
+      const marker = availableProviders[i] === config.providers.default ? ' (current)' : '';
+      console.log(chalk.white(`    ${i + 1}. ${availableProviders[i]}${marker}`));
+    }
+    console.log('');
+    const choice = await ask(chalk.white(`  Choose [1-${availableProviders.length}] [Enter to keep ${config.providers.default}]: `));
+    const num = parseInt(choice, 10);
+    if (num >= 1 && num <= availableProviders.length) {
+      config.providers.default = availableProviders[num - 1];
+    }
+  } else if (!isReconfig) {
+    config.providers.default = availableProviders[0];
+    console.log(chalk.dim(`  Default provider set to ${config.providers.default}`));
   }
 
   hr();

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { Agent } from './core/agent.js';
 import { Scheduler } from './core/scheduler.js';
 import { ChannelRegistry } from './channels/registry.js';
 import { CLIChannel } from './channels/cli.js';
+import { TelegramChannel } from './channels/telegram.js';
 import { TokenBudget } from './utils/tokens.js';
 import { CapabilityRegistry } from './capabilities/registry.js';
 import { SkillLoader } from './skills/loader.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,8 @@ import { TokenBudget } from './utils/tokens.js';
 import { CapabilityRegistry } from './capabilities/registry.js';
 import { SkillLoader } from './skills/loader.js';
 import { getManual } from './utils/manual.js';
-import { startBackground, stopDaemon, showLogs, getDaemonStatus } from './cli/daemon.js';
-import { installService, uninstallService, showServiceStatus } from './cli/service.js';
+import { startBackground, stopDaemon, showLogs, getDaemonStatus, restartDaemon } from './cli/daemon.js';
+import { installService, uninstallService, showServiceStatus, isServiceInstalled } from './cli/service.js';
 import { runWithWatchdog } from './cli/watchdog.js';
 
 function hr() {
@@ -346,6 +346,41 @@ program
   .description('Stop a background Mercury process')
   .action(() => {
     stopDaemon();
+  });
+
+program
+  .command('restart')
+  .description('Restart a background Mercury process')
+  .action(() => {
+    restartDaemon();
+  });
+
+program
+  .command('up')
+  .description('Ensure Mercury is running persistently — installs service if needed, starts daemon')
+  .action(async () => {
+    if (!isSetupComplete()) {
+      await configure();
+    }
+
+    const daemon = getDaemonStatus();
+
+    if (daemon.running && daemon.pid) {
+      console.log('');
+      console.log(chalk.green(`  Mercury is already running (PID: ${daemon.pid})`));
+      console.log(chalk.dim(`  Logs: ${daemon.logPath}`));
+      console.log('');
+      return;
+    }
+
+    if (!isServiceInstalled()) {
+      console.log('');
+      console.log(chalk.cyan('  Installing Mercury as a system service...'));
+      installService();
+    }
+
+    console.log(chalk.cyan('  Starting Mercury in background...'));
+    startBackground();
   });
 
 program

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,6 +38,7 @@ export interface MercuryConfig {
       botToken: string;
       webhookUrl?: string;
       allowedChatIds?: number[];
+      streaming?: boolean;
     };
   };
   memory: {
@@ -109,6 +110,7 @@ export function getDefaultConfig(): MercuryConfig {
           .split(',')
           .filter(Boolean)
           .map(Number),
+        streaming: getEnvBool('TELEGRAM_STREAMING', true),
       },
     },
     memory: {

--- a/src/utils/manual.ts
+++ b/src/utils/manual.ts
@@ -49,10 +49,17 @@ export function getManual(): string {
 
   const commands = [
     ['mercury', 'Start the agent (same as mercury start)'],
-    ['mercury start', 'Start the agent'],
+    ['mercury start', 'Start the agent in foreground'],
+    ['mercury start -d', 'Start in background (daemon mode)'],
+    ['mercury stop', 'Stop a background Mercury process'],
+    ['mercury logs', 'Show recent daemon logs'],
+    ['mercury doctor', 'Reconfigure settings (Enter keeps current)'],
     ['mercury setup', 'Re-run the setup wizard'],
-    ['mercury status', 'Show current configuration'],
+    ['mercury status', 'Show config and daemon status'],
     ['mercury help', 'Show this manual'],
+    ['mercury service install', 'Install as system service (auto-start)'],
+    ['mercury service uninstall', 'Uninstall system service'],
+    ['mercury service status', 'Show system service status'],
     ['mercury --verbose', 'Start with debug logging on stderr'],
   ];
 

--- a/src/utils/manual.ts
+++ b/src/utils/manual.ts
@@ -48,10 +48,12 @@ export function getManual(): string {
   sections.push('');
 
   const commands = [
+    ['mercury up', 'Start persistently (install service + daemon)'],
     ['mercury', 'Start the agent (same as mercury start)'],
     ['mercury start', 'Start the agent in foreground'],
     ['mercury start -d', 'Start in background (daemon mode)'],
-    ['mercury stop', 'Stop a background Mercury process'],
+    ['mercury restart', 'Restart a background process'],
+    ['mercury stop', 'Stop a background process'],
     ['mercury logs', 'Show recent daemon logs'],
     ['mercury doctor', 'Reconfigure settings (Enter keeps current)'],
     ['mercury setup', 'Re-run the setup wizard'],

--- a/src/utils/manual.ts
+++ b/src/utils/manual.ts
@@ -79,6 +79,9 @@ export function getManual(): string {
     ['/status', 'Show config and budget info'],
     ['/tools', 'List currently loaded tools'],
     ['/skills', 'List installed skills'],
+    ['/stream', 'Toggle text streaming on/off (Telegram)'],
+    ['/stream on', 'Enable streaming (live text updates)'],
+    ['/stream off', 'Disable streaming (single message)'],
   ];
 
   for (const [cmd, desc] of chat) {


### PR DESCRIPTION
## What's new

Mercury now runs 24/7 as a background daemon on any platform — no PM2, forever, or NSSM required. This is the biggest feature drop since launch.

## Daemon Mode

- `mercury start -d` — run in background with PID file + log redirect
- `mercury stop` — stop the background process
- `mercury restart` — restart the process (stop + start fresh)
- Built-in watchdog with exponential backoff crash recovery (max 10 restarts/60s)
- Auto-daemonize on first setup — after onboarding, Mercury silently installs the service and starts the daemon. Fails gracefully with a hint if something goes wrong

## `mercury up` — One Command to Rule Them All

- Installs the system service (if not installed), starts the daemon, confirms running
- If already running, just shows the PID
- This is the recommended command for all users

## System Service (auto-start on boot)

| Platform | Method | Admin Required |
|----------|--------|----------------|
| macOS | `~/Library/LaunchAgents/` plist | No |
| Linux | `~/.config/systemd/user/` unit | No (linger for boot) |
| Windows | Task Scheduler (`schtasks`) | No |

- `mercury service install` / `uninstall` / `status`
- All services use the `--daemon` flag for crash recovery

## CLI Overhaul

- `mercury help` — full manual (tools, commands, config paths)
- `mercury doctor` — reconfigure with masked keys, Enter keeps current values
- `mercury status` — now shows daemon PID and status
- `mercury logs` — tail last 100 lines of daemon log
- Provider selection during `mercury doctor` — choose default from available providers

## In-Chat Commands (zero API tokens)

- `/help` `/status` `/tools` `/skills` — work on CLI and Telegram
- `/budget` `/budget override` `/budget reset` `/budget set <n>`

## Telegram Improvements

- **Slash commands menu** — `/help`, `/status`, `/tools`, `/skills`, `/budget`, `/stream` registered via `setMyCommands()`
- **Text streaming** — responses appear progressively via message editing with live `▌` cursor, final message renders with full HTML formatting
- **`/stream` toggle** — tap to toggle on/off, or use `/stream on` / `/stream off`
- Streaming enabled by default, configurable via `channels.telegram.streaming` in config

## Documentation

- New `docs/docs.html` — full documentation page with sidebar navigation, platform-specific tabs (macOS/Linux/Windows), command reference tables, tool reference, configuration paths
- Updated landing page with daemon mode section and `mercury up` demo
- README updated with all new commands and features

## Architecture Decision

- ADR-009 added to DECISIONS.md: Custom Hybrid Daemonization — why we didn't use PM2, forever, node-windows/mac/linux, or native detached-only

## Files changed

- 13 files changed, ~2,300 insertions
- New: `src/cli/daemon.ts`, `src/cli/watchdog.ts`, `src/cli/service.ts`, `docs/docs.html`
- Modified: `src/index.ts`, `src/core/agent.ts`, `src/channels/telegram.ts`, `src/capabilities/registry.ts`, `src/utils/config.ts`, `src/utils/manual.ts`, `README.md`, `DECISIONS.md`, `docs/index.html`