### PR TITLE
feat: add DeepSeek V4 models (deepseek-v4-flash, deepseek-v4-pro)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ ANTHROPIC_MODEL=claude-sonnet-4-20250514
 # DeepSeek (uses OpenAI-compatible API)
 DEEPSEEK_API_KEY=
 DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
-DEEPSEEK_MODEL=deepseek-chat
+DEEPSEEK_MODEL=deepseek-v4-flash
 
 # Grok / xAI (OpenAI-compatible API)
 GROK_API_KEY=

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -1,0 +1,260 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, streamText } from 'ai';
+import { BaseProvider } from './base.js';
+import type { ProviderConfig } from '../utils/config.js';
+import type { LLMResponse, LLMStreamChunk } from './base.js';
+import { logger } from '../utils/logger.js';
+
+interface ReasoningEntry {
+  reasoning: string;
+}
+
+const MAX_STORE_SIZE = 50;
+
+export class DeepSeekProvider extends BaseProvider {
+  readonly name: string;
+  readonly model: string;
+  private client: ReturnType<typeof createOpenAI>;
+  private modelInstance: ReturnType<ReturnType<typeof createOpenAI>['languageModel']>;
+  private reasoningByText = new Map<string, ReasoningEntry>();
+  private reasoningByToolCalls = new Map<string, ReasoningEntry>();
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    this.name = config.name;
+    this.model = config.model;
+
+    const self = this;
+    const originalFetch = globalThis.fetch.bind(globalThis);
+
+    this.client = createOpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseUrl,
+      fetch: async (url: string | URL | Request, init?: RequestInit) => {
+        // --- Request interception: inject reasoning into assistant messages ---
+        if (init?.body && typeof init.body === 'string') {
+          try {
+            const body = JSON.parse(init.body);
+            if (body.messages && Array.isArray(body.messages)) {
+              let modified = false;
+              for (const msg of body.messages) {
+                if (msg.role === 'assistant' && !msg.reasoning_content) {
+                  const reasoning = self.findReasoning(msg);
+                  if (reasoning) {
+                    msg.reasoning_content = reasoning;
+                    modified = true;
+                  }
+                }
+              }
+              if (modified) {
+                init = { ...init, body: JSON.stringify(body) };
+              }
+            }
+          } catch {
+            // Send as-is if parsing fails
+          }
+        }
+
+        // --- Make the actual request ---
+        const response = await originalFetch(url, init);
+
+        if (!response.ok) return response;
+
+        const contentType = response.headers.get('content-type') ?? '';
+
+        // --- Response interception ---
+        if (contentType.includes('text/event-stream')) {
+          return self.interceptStream(response);
+        }
+
+        return self.interceptJson(response);
+      },
+    });
+
+    this.modelInstance = this.client(config.model);
+  }
+
+  private findReasoning(msg: Record<string, any>): string | null {
+    const content = (msg.content ?? '').trim();
+
+    // Match by text content
+    if (content) {
+      const entry = this.reasoningByText.get(content);
+      if (entry) return entry.reasoning;
+    }
+
+    // Fallback: match by tool_calls signature (for responses with no text, only tool_calls)
+    if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
+      const sig = msg.tool_calls
+        .map((tc: Record<string, any>) => tc.function?.name ?? '')
+        .filter(Boolean)
+        .join(',');
+      if (sig) {
+        const entry = this.reasoningByToolCalls.get(sig);
+        if (entry) return entry.reasoning;
+      }
+    }
+
+    return null;
+  }
+
+  private storeReasoning(textContent: string, toolCallsSignature: string, reasoning: string): void {
+    if (!reasoning) return;
+
+    if (this.reasoningByText.size > MAX_STORE_SIZE) {
+      this.reasoningByText.clear();
+      this.reasoningByToolCalls.clear();
+    }
+
+    if (textContent) {
+      this.reasoningByText.set(textContent, { reasoning });
+    }
+    if (toolCallsSignature) {
+      this.reasoningByToolCalls.set(toolCallsSignature, { reasoning });
+    }
+  }
+
+  private interceptJson(response: Response): Response {
+    const clone = response.clone();
+
+    clone
+      .json()
+      .then((json: any) => {
+        const reasoning: string | undefined =
+          json.choices?.[0]?.message?.reasoning_content;
+        const content: string = json.choices?.[0]?.message?.content ?? '';
+        const toolCalls: Array<Record<string, any>> | undefined =
+          json.choices?.[0]?.message?.tool_calls;
+        const toolCallsSignature = toolCalls
+          ?.map((tc: any) => tc.function?.name ?? '')
+          .filter(Boolean)
+          .join(',') ?? '';
+
+        if (reasoning) {
+          this.storeReasoning(content.trim(), toolCallsSignature, reasoning);
+          logger.debug(
+            { contentLen: content.length, reasoningLen: reasoning.length },
+            'DeepSeek: captured reasoning from JSON response',
+          );
+        }
+      })
+      .catch(() => {
+        // Ignore parse errors
+      });
+
+    return response;
+  }
+
+  private interceptStream(response: Response): Response {
+    const self = this;
+    let accumulatedReasoning = '';
+    let accumulatedText = '';
+    let accumulatedToolCallNames: string[] = [];
+    let buffer = '';
+
+    const transform = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        // Pass through the raw bytes unchanged
+        controller.enqueue(chunk);
+
+        // Decode and parse SSE lines to capture reasoning
+        buffer += new TextDecoder().decode(chunk, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ') || line === 'data: [DONE]') continue;
+          try {
+            const json = JSON.parse(line.slice(6));
+            const delta = json.choices?.[0]?.delta;
+            if (delta?.reasoning_content) {
+              accumulatedReasoning += delta.reasoning_content;
+            }
+            if (delta?.content) {
+              accumulatedText += delta.content;
+            }
+            if (delta?.tool_calls) {
+              for (const tc of delta.tool_calls) {
+                if (tc.function?.name) {
+                  accumulatedToolCallNames.push(tc.function.name);
+                }
+              }
+            }
+            // Store when this choice finishes
+            if (json.choices?.[0]?.finish_reason && accumulatedReasoning) {
+              const toolCallsSignature = accumulatedToolCallNames.join(',');
+              self.storeReasoning(
+                accumulatedText.trim(),
+                toolCallsSignature,
+                accumulatedReasoning,
+              );
+              logger.debug(
+                {
+                  contentLen: accumulatedText.length,
+                  reasoningLen: accumulatedReasoning.length,
+                  toolCalls: toolCallsSignature,
+                },
+                'DeepSeek: captured reasoning from stream',
+              );
+              // Reset accumulators for potential next choice in the same stream
+              accumulatedReasoning = '';
+              accumulatedText = '';
+              accumulatedToolCallNames = [];
+            }
+          } catch {
+            // Ignore parse errors for partial data
+          }
+        }
+      },
+    });
+
+    return new Response(response.body!.pipeThrough(transform), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  async generateText(prompt: string, systemPrompt: string): Promise<LLMResponse> {
+    const result = await generateText({
+      model: this.modelInstance,
+      system: systemPrompt,
+      prompt,
+    });
+
+    return {
+      text: result.text,
+      inputTokens: result.usage?.promptTokens ?? 0,
+      outputTokens: result.usage?.completionTokens ?? 0,
+      totalTokens:
+        (result.usage?.promptTokens ?? 0) +
+        (result.usage?.completionTokens ?? 0),
+      model: this.model,
+      provider: this.name,
+    };
+  }
+
+  async *streamText(
+    prompt: string,
+    systemPrompt: string,
+  ): AsyncIterable<LLMStreamChunk> {
+    const result = streamText({
+      model: this.modelInstance,
+      system: systemPrompt,
+      prompt,
+    });
+
+    for await (const chunk of (await result).textStream) {
+      yield { text: chunk, done: false };
+    }
+    yield { text: '', done: true };
+  }
+
+  isAvailable(): boolean {
+    return this.config.apiKey.length > 0;
+  }
+
+  getModelInstance() {
+    return this.modelInstance;
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 export { BaseProvider } from './base.js';
 export { OpenAICompatProvider } from './openai-compat.js';
 export { AnthropicProvider } from './anthropic.js';
+export { DeepSeekProvider } from './deepseek.js';
 export { OllamaProvider } from './ollama.js';
 export { ProviderRegistry } from './registry.js';
 export type { LLMResponse, LLMStreamChunk } from './base.js';

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -3,6 +3,7 @@ import { isProviderConfigured } from '../utils/config.js';
 import type { BaseProvider } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { AnthropicProvider } from './anthropic.js';
+import { DeepSeekProvider } from './deepseek.js';
 import { OllamaProvider } from './ollama.js';
 import { logger } from '../utils/logger.js';
 
@@ -29,6 +30,8 @@ export class ProviderRegistry {
         let provider: BaseProvider;
         if (pc.name === 'anthropic') {
           provider = new AnthropicProvider(pc);
+        } else if (pc.name === 'deepseek') {
+          provider = new DeepSeekProvider(pc);
         } else if (pc.name === 'ollamaCloud' || pc.name === 'ollamaLocal') {
           provider = new OllamaProvider(pc);
         } else {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -149,7 +149,7 @@ export function getDefaultConfig(): MercuryConfig {
         name: 'deepseek',
         apiKey: getEnv('DEEPSEEK_API_KEY', ''),
         baseUrl: getEnv('DEEPSEEK_BASE_URL', 'https://api.deepseek.com/v1'),
-        model: getEnv('DEEPSEEK_MODEL', 'deepseek-chat'),
+        model: getEnv('DEEPSEEK_MODEL', 'deepseek-v4-flash'),
         enabled: getEnvBool('DEEPSEEK_ENABLED', true),
       },
       grok: {

--- a/src/utils/provider-models.test.ts
+++ b/src/utils/provider-models.test.ts
@@ -26,6 +26,30 @@ describe('buildModelCatalog', () => {
     expect(catalog.recommendedModel).toBe('llama3.2:latest');
   });
 
+  it('prefers deepseek-v4-flash for DeepSeek provider', () => {
+    const catalog = buildModelCatalog('deepseek', [
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'deepseek-chat',
+      'deepseek-reasoner',
+    ]);
+
+    expect(catalog.recommendedModel).toBe('deepseek-v4-flash');
+    expect(catalog.models).toContain('deepseek-v4-pro');
+    expect(catalog.models).toContain('deepseek-chat');
+    expect(catalog.models).toContain('deepseek-reasoner');
+    expect(catalog.models).not.toContain('deepseek-v4-flash');
+  });
+
+  it('falls back to legacy DeepSeek models when v4 models are unavailable', () => {
+    const catalog = buildModelCatalog('deepseek', [
+      'deepseek-chat',
+      'deepseek-reasoner',
+    ]);
+
+    expect(catalog.recommendedModel).toBe('deepseek-chat');
+  });
+
   it('limits the list of displayed models', () => {
     const catalog = buildModelCatalog('anthropic', [
       'claude-sonnet-4-20250514',

--- a/src/utils/provider-models.ts
+++ b/src/utils/provider-models.ts
@@ -28,6 +28,8 @@ const ANTHROPIC_PREFERRED_MODELS = [
 ] as const;
 
 const DEEPSEEK_PREFERRED_MODELS = [
+  'deepseek-v4-flash',
+  'deepseek-v4-pro',
   'deepseek-chat',
   'deepseek-reasoner',
 ] as const;


### PR DESCRIPTION
## Summary

- Add `deepseek-v4-flash` and `deepseek-v4-pro` to `DEEPSEEK_PREFERRED_MODELS`
- Change default DeepSeek model from `deepseek-chat` to `deepseek-v4-flash`
- Add test cases for new model recommendation logic
- Update `.env.example` with new default model
- **Fix**: Create custom `DeepSeekProvider` to handle `reasoning_content` round-trip in multi-step tool calls

DeepSeek released V4 models today (2026-04-24). The legacy model names (`deepseek-chat`, `deepseek-reasoner`) are kept in the preferred list for backward compatibility until their deprecation on 2026/07/24.

### Reasoning Content Fix

DeepSeek V4 models default to thinking mode, returning `reasoning_content` in responses. The `@ai-sdk/openai` adapter strips this field at three levels (Zod schema, message converter, `isReasoningModel` check). In multi-step tool call flows (`maxSteps`), the SDK re-sends assistant messages without `reasoning_content`, causing the DeepSeek API to return 400 errors.

The new `DeepSeekProvider` wraps `createOpenAI` with a custom `fetch` function that:
- **Captures** `reasoning_content` from streaming (SSE) and non-streaming responses
- **Injects** stored reasoning into assistant messages in subsequent requests
- Matches reasoning by text content with tool_calls signature fallback

**New model details:**
| Model | Context | Max Output | Thinking Mode |
|---|---|---|---|
| deepseek-v4-flash | 1M | 384K | Yes (default) |
| deepseek-v4-pro | 1M | 384K | Yes |

## Test plan

- [x] All 22 tests pass (`npx vitest run`)
- [x] Added 2 new test cases for DeepSeek model recommendation
- [x] Verified `deepseek-v4-flash` model via live API call (returns `reasoning_content` in thinking mode)
- [x] Legacy models still in preferred list for backward compatibility
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)