### PR TITLE
feat: add OpenCode Go provider integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,6 +60,7 @@ src/
 │   ├── base.ts           # Abstract provider + getModelInstance()
 │   ├── openai-compat.ts
 │   ├── anthropic.ts
+│   ├── opencode-go.ts    # OpenCode Go (dual OpenAI/Anthropic SDK)
 │   └── registry.ts
 ├── soul/                 # Consciousness
 │   └── identity.ts       # Soul/persona/taste loader + guardrails

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Configure multiple LLM providers. Mercury tries them in order and falls back aut
 | **OpenAI** | gpt-4o-mini | `OPENAI_API_KEY` | GPT-4o, o3, etc. |
 | **Anthropic** | claude-sonnet-4 | `ANTHROPIC_API_KEY` | Claude Sonnet, Haiku, Opus |
 | **Grok (xAI)** | grok-4 | `GROK_API_KEY` | OpenAI-compatible endpoint |
+| **OpenCode Go** | kimi-k2.6 | `OPENCODE_GO_API_KEY` | OpenAI/Anthropic-compatible, 14+ open models |
 | **Ollama Cloud** | gpt-oss:120b | `OLLAMA_CLOUD_API_KEY` | Remote Ollama via API |
 | **Ollama Local** | gpt-oss:20b | No key needed | Local Ollama instance |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ const PROVIDER_OPTIONS: Array<{ key: ProviderName; label: string }> = [
   { key: 'openai', label: 'OpenAI' },
   { key: 'anthropic', label: 'Anthropic' },
   { key: 'grok', label: 'Grok (xAI)' },
+  { key: 'opencodeGo', label: 'OpenCode Go' },
   { key: 'ollamaCloud', label: 'Ollama Cloud' },
   { key: 'ollamaLocal', label: 'Ollama Local' },
 ];
@@ -245,6 +246,12 @@ function validateApiKey(provider: ProviderName, value: string): string | null {
     return looksLikeToken(value)
       ? null
       : 'Ollama Cloud keys must look like a real API token: long, no spaces, and not plain text.';
+  }
+
+  if (provider === 'opencodeGo') {
+    return looksLikeToken(value)
+      ? null
+      : 'OpenCode Go keys must look like a real API token: long, no spaces, and not plain text.';
   }
 
   return null;
@@ -638,6 +645,23 @@ async function configure(existingConfig?: MercuryConfig): Promise<void> {
           config.providers.grok.apiKey = result.apiKey;
           config.providers.grok.model = result.model;
           config.providers.grok.enabled = true;
+        }
+        continue;
+      }
+
+      if (provider === 'opencodeGo') {
+        const mask = isReconfig && config.providers.opencodeGo.apiKey ? ` [${maskKey(config.providers.opencodeGo.apiKey)}]` : '';
+        const result = await promptApiKeyWithModelSelection(
+          config,
+          'opencodeGo',
+          'OpenCode Go',
+          chalk.white(`  OpenCode Go API key${mask}${isReconfig ? '' : ' (Enter to skip)'}: `),
+          isReconfig,
+        );
+        if (!result.skipped && result.apiKey && result.model) {
+          config.providers.opencodeGo.apiKey = result.apiKey;
+          config.providers.opencodeGo.model = result.model;
+          config.providers.opencodeGo.enabled = true;
         }
         continue;
       }

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -1,0 +1,76 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText, streamText } from 'ai';
+import { BaseProvider } from './base.js';
+import type { ProviderConfig } from '../utils/config.js';
+import type { LLMResponse, LLMStreamChunk } from './base.js';
+
+const ANTHROPIC_COMPAT_MODELS = new Set([
+  'deepseek-v4-pro',
+  'deepseek-v4-flash',
+  'minimax-m2.7',
+  'minimax-m2.5',
+]);
+
+export class OpenCodeGoProvider extends BaseProvider {
+  readonly name = 'opencodeGo';
+  readonly model: string;
+  private client: any;
+  private modelInstance: any;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    this.model = config.model;
+
+    if (ANTHROPIC_COMPAT_MODELS.has(config.model)) {
+      this.client = createAnthropic({
+        apiKey: config.apiKey,
+        baseURL: config.baseUrl,
+      });
+    } else {
+      this.client = createOpenAI({
+        apiKey: config.apiKey,
+        baseURL: config.baseUrl,
+      });
+    }
+    this.modelInstance = this.client(config.model);
+  }
+
+  async generateText(prompt: string, systemPrompt: string): Promise<LLMResponse> {
+    const result = await generateText({
+      model: this.modelInstance,
+      system: systemPrompt,
+      prompt,
+    });
+
+    return {
+      text: result.text,
+      inputTokens: result.usage?.promptTokens ?? 0,
+      outputTokens: result.usage?.completionTokens ?? 0,
+      totalTokens: (result.usage?.promptTokens ?? 0) + (result.usage?.completionTokens ?? 0),
+      model: this.model,
+      provider: this.name,
+    };
+  }
+
+  async *streamText(prompt: string, systemPrompt: string): AsyncIterable<LLMStreamChunk> {
+    const result = streamText({
+      model: this.modelInstance,
+      system: systemPrompt,
+      prompt,
+    });
+
+    for await (const chunk of (await result).textStream) {
+      yield { text: chunk, done: false };
+    }
+    yield { text: '', done: true };
+  }
+
+  isAvailable(): boolean {
+    return this.config.apiKey.length > 0;
+  }
+
+  getModelInstance() {
+    return this.modelInstance;
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -3,6 +3,7 @@ import { isProviderConfigured } from '../utils/config.js';
 import type { BaseProvider } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { AnthropicProvider } from './anthropic.js';
+import { OpenCodeGoProvider } from './opencode-go.js';
 import { OllamaProvider } from './ollama.js';
 import { logger } from '../utils/logger.js';
 
@@ -19,6 +20,7 @@ export class ProviderRegistry {
       config.providers.openai,
       config.providers.anthropic,
       config.providers.grok,
+      config.providers.opencodeGo,
       config.providers.ollamaCloud,
       config.providers.ollamaLocal,
     ];
@@ -29,6 +31,8 @@ export class ProviderRegistry {
         let provider: BaseProvider;
         if (pc.name === 'anthropic') {
           provider = new AnthropicProvider(pc);
+        } else if (pc.name === 'opencodeGo') {
+          provider = new OpenCodeGoProvider(pc);
         } else if (pc.name === 'ollamaCloud' || pc.name === 'ollamaLocal') {
           provider = new OllamaProvider(pc);
         } else {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -51,6 +51,7 @@ export type ProviderName =
   | 'anthropic'
   | 'deepseek'
   | 'grok'
+  | 'opencodeGo'
   | 'ollamaCloud'
   | 'ollamaLocal';
 
@@ -66,6 +67,7 @@ export interface MercuryConfig {
     anthropic: ProviderConfig;
     deepseek: ProviderConfig;
     grok: ProviderConfig;
+    opencodeGo: ProviderConfig;
     ollamaCloud: ProviderConfig;
     ollamaLocal: ProviderConfig;
   };
@@ -158,6 +160,13 @@ export function getDefaultConfig(): MercuryConfig {
         baseUrl: getEnv('GROK_BASE_URL', 'https://api.x.ai/v1'),
         model: getEnv('GROK_MODEL', 'grok-4'),
         enabled: getEnvBool('GROK_ENABLED', true),
+      },
+      opencodeGo: {
+        name: 'opencodeGo',
+        apiKey: getEnv('OPENCODE_GO_API_KEY', ''),
+        baseUrl: getEnv('OPENCODE_GO_BASE_URL', 'https://opencode.ai/zen/go/v1'),
+        model: getEnv('OPENCODE_GO_MODEL', 'kimi-k2.6'),
+        enabled: getEnvBool('OPENCODE_GO_ENABLED', true),
       },
       ollamaCloud: {
         name: 'ollamaCloud',

--- a/src/utils/provider-models.ts
+++ b/src/utils/provider-models.ts
@@ -40,6 +40,23 @@ const GROK_PREFERRED_MODELS = [
   'grok-3-latest',
 ] as const;
 
+const OPENCODE_GO_PREFERRED_MODELS = [
+  'kimi-k2.6',
+  'kimi-k2.5',
+  'glm-5.1',
+  'glm-5',
+  'deepseek-v4-pro',
+  'deepseek-v4-flash',
+  'qwen3.6-plus',
+  'qwen3.5-plus',
+  'mimo-v2.5-pro',
+  'mimo-v2.5',
+  'mimo-v2-pro',
+  'mimo-v2-omni',
+  'minimax-m2.7',
+  'minimax-m2.5',
+] as const;
+
 const OLLAMA_CLOUD_PREFERRED_MODELS = [
   'gpt-oss:120b',
   'gpt-oss:120b-cloud',
@@ -152,6 +169,7 @@ function chooseRecommendedModel(
     openai: OPENAI_PREFERRED_MODELS,
     anthropic: ANTHROPIC_PREFERRED_MODELS,
     grok: GROK_PREFERRED_MODELS,
+    opencodeGo: OPENCODE_GO_PREFERRED_MODELS,
     ollamaCloud: OLLAMA_CLOUD_PREFERRED_MODELS,
     ollamaLocal: OLLAMA_LOCAL_PREFERRED_MODELS,
   };
@@ -185,6 +203,7 @@ export function buildModelCatalog(
     openai: OPENAI_PREFERRED_MODELS,
     anthropic: ANTHROPIC_PREFERRED_MODELS,
     grok: GROK_PREFERRED_MODELS,
+    opencodeGo: OPENCODE_GO_PREFERRED_MODELS,
     ollamaCloud: OLLAMA_CLOUD_PREFERRED_MODELS,
     ollamaLocal: OLLAMA_LOCAL_PREFERRED_MODELS,
   };
@@ -281,6 +300,34 @@ async function fetchOllamaModels(provider: ProviderName, config: ProviderConfig)
   return buildModelCatalog(provider, ids, config.model);
 }
 
+async function fetchOpenCodeGoModels(config: ProviderConfig): Promise<ProviderModelCatalog> {
+  const data = await fetchJson<OpenAIModelResponse>(
+    `${trimTrailingSlash(config.baseUrl)}/models`,
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+    },
+    'Mercury could not fetch models for this OpenCode Go key. Please re-enter it.',
+  );
+
+  const ids = (data.data ?? [])
+    .map((model) => model.id?.trim() ?? '')
+    .filter((id) => {
+      const lower = id.toLowerCase();
+      return (
+        lower.startsWith('glm-')
+        || lower.startsWith('kimi-')
+        || lower.startsWith('mimo-')
+        || lower.startsWith('minimax-')
+        || lower.startsWith('qwen')
+        || lower.startsWith('deepseek-')
+      );
+    });
+
+  return buildModelCatalog('opencodeGo', ids, config.model);
+}
+
 export async function fetchProviderModelCatalog(
   provider: ProviderName,
   config: ProviderConfig,
@@ -291,6 +338,10 @@ export async function fetchProviderModelCatalog(
 
   if (provider === 'grok') {
     return fetchGrokModels(config);
+  }
+
+  if (provider === 'opencodeGo') {
+    return fetchOpenCodeGoModels(config);
   }
 
   if (provider === 'ollamaCloud' || provider === 'ollamaLocal') {

--- a/src/utils/provider-models.ts
+++ b/src/utils/provider-models.ts
@@ -300,32 +300,25 @@ async function fetchOllamaModels(provider: ProviderName, config: ProviderConfig)
   return buildModelCatalog(provider, ids, config.model);
 }
 
+const OPENCODE_GO_KNOWN_MODELS = [
+  'glm-5.1',
+  'glm-5',
+  'kimi-k2.5',
+  'kimi-k2.6',
+  'deepseek-v4-pro',
+  'deepseek-v4-flash',
+  'mimo-v2-pro',
+  'mimo-v2-omni',
+  'mimo-v2.5-pro',
+  'mimo-v2.5',
+  'minimax-m2.5',
+  'minimax-m2.7',
+  'qwen3.5-plus',
+  'qwen3.6-plus',
+];
+
 async function fetchOpenCodeGoModels(config: ProviderConfig): Promise<ProviderModelCatalog> {
-  const data = await fetchJson<OpenAIModelResponse>(
-    `${trimTrailingSlash(config.baseUrl)}/models`,
-    {
-      headers: {
-        Authorization: `Bearer ${config.apiKey}`,
-      },
-    },
-    'Mercury could not fetch models for this OpenCode Go key. Please re-enter it.',
-  );
-
-  const ids = (data.data ?? [])
-    .map((model) => model.id?.trim() ?? '')
-    .filter((id) => {
-      const lower = id.toLowerCase();
-      return (
-        lower.startsWith('glm-')
-        || lower.startsWith('kimi-')
-        || lower.startsWith('mimo-')
-        || lower.startsWith('minimax-')
-        || lower.startsWith('qwen')
-        || lower.startsWith('deepseek-')
-      );
-    });
-
-  return buildModelCatalog('opencodeGo', ids, config.model);
+  return buildModelCatalog('opencodeGo', [...OPENCODE_GO_KNOWN_MODELS], config.model);
 }
 
 export async function fetchProviderModelCatalog(


### PR DESCRIPTION
## Summary
This PR adds full support for [OpenCode Go](https://opencode.ai) as a first-class LLM provider in Mercury. OpenCode Go is a low-cost subscription ($5 first month, then $10/mo) that provides reliable access to a curated set of popular open-source coding models.

## Why
OpenCode Go offers 14+ high-quality open models (Kimi K2.6, GLM-5.1, DeepSeek V4 Pro, Qwen3.6 Plus, etc.) with global hosting and OpenAI/Anthropic-compatible endpoints. Adding this provider gives Mercury users more choice and cost-effective access to strong open models without managing individual API keys for each model family.

## Supported Models
| Model | ID | SDK |
| GLM-5.1 | `glm-5.1` | OpenAI |
| GLM-5 | `glm-5` | OpenAI |
| Kimi K2.5 | `kimi-k2.5` | OpenAI |
| Kimi K2.6 | `kimi-k2.6` | OpenAI |
| MiMo-V2-Pro | `mimo-v2-pro` | OpenAI |
| MiMo-V2-Omni | `mimo-v2-omni` | OpenAI |
| MiMo-V2.5-Pro | `mimo-v2.5-pro` | OpenAI |
| MiMo-V2.5 | `mimo-v2.5` | OpenAI |
| Qwen3.6 Plus | `qwen3.6-plus` | OpenAI |
| Qwen3.5 Plus | `qwen3.5-plus` | OpenAI |
| DeepSeek V4 Pro | `deepseek-v4-pro` | Anthropic |
| DeepSeek V4 Flash | `deepseek-v4-flash` | Anthropic |
| MiniMax M2.7 | `minimax-m2.7` | Anthropic |
| MiniMax M2.5 | `minimax-m2.5` | Anthropic |

## Checklist
- [x] Added new provider with dual SDK support
- [x] Updated configuration types and defaults
- [x] Updated provider registry
- [x] Updated model discovery/fetching
- [x] Updated CLI setup wizard
- [x] Updated documentation (README, ARCHITECTURE)
- [x] Build passes (`npm run build`)
- [x] Type check passes (`npm run typecheck`)