### PR TITLE
feat: add Z.ai provider, lightweight web panel, and Discord channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,12 +38,48 @@ OLLAMA_LOCAL_BASE_URL=http://127.0.0.1:11434/api
 OLLAMA_LOCAL_MODEL=gpt-oss:20b
 OLLAMA_LOCAL_ENABLED=false
 
-# Default provider: deepseek | openai | anthropic | grok | ollamaCloud | ollamaLocal
+# Default provider: deepseek | openai | anthropic | grok | ollamaCloud | ollamaLocal | zai
 DEFAULT_PROVIDER=deepseek
+
+# Z.ai / GLM (OpenAI-compatible API)
+ZAI_API_KEY=
+ZAI_BASE_URL=https://api.z.ai/api/paas/v4
+ZAI_MODEL=glm-5.1
+ZAI_ENABLED=true
+# Enable Z.ai Coding Plan endpoint (opt-in — see docs/providers/zai.md)
+ZAI_CODING_PLAN_ENABLED=false
+ZAI_CODING_PLAN_BASE_URL=https://api.z.ai/api/coding/paas/v4
 
 # ── Telegram ──
 # Get a bot token from @BotFather on Telegram
 TELEGRAM_BOT_TOKEN=
+
+# ── Web Panel (optional) ──
+# Enable a lightweight browser-based chat panel
+WEB_PANEL_ENABLED=false
+WEB_PANEL_HOST=127.0.0.1
+WEB_PANEL_PORT=3977
+# Auth token for remote access (required if binding to 0.0.0.0)
+WEB_PANEL_AUTH_TOKEN=
+# Explicitly allow remote access without auth token (NOT recommended)
+WEB_PANEL_ALLOW_REMOTE=false
+
+# ── Discord (optional) ──
+# Enable Discord bot integration using slash commands
+DISCORD_ENABLED=false
+DISCORD_BOT_TOKEN=
+DISCORD_CLIENT_ID=
+DISCORD_GUILD_ID=
+# Comma-separated user IDs allowed to use the bot
+DISCORD_ALLOWED_USER_IDS=
+# Comma-separated channel IDs where the bot operates
+DISCORD_ALLOWED_CHANNEL_IDS=
+# Comma-separated admin user IDs (full control)
+DISCORD_ADMIN_USER_IDS=
+# Register commands globally (slow to propagate, use for production)
+DISCORD_USE_GLOBAL_COMMANDS=false
+# Allow DM interactions (disabled by default for safety)
+DISCORD_ALLOW_DMS=false
 
 # ── Memory ──
 MEMORY_DIR=./memory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Z.ai (GLM) provider** — first-class support for Z.ai's OpenAI-compatible API with opt-in GLM Coding Plan endpoint (`ZAI_CODING_PLAN_ENABLED`)
+- **Web Panel channel** — lightweight browser-based interface using Node.js built-in HTTP, defaulting to localhost with optional auth token for remote access
+- **Discord channel** — slash command bot with allowlist access control, deferred responses, and minimal Gateway intents
+- `docs/providers/zai.md` — Z.ai provider setup and Coding Plan compliance documentation
+- `docs/channels/web-panel.md` — Web Panel setup and security documentation
+- `docs/channels/discord.md` — Discord bot setup and access control documentation
+
 ## 1.0.0 — Second Brain
 
 This is a **major release** because it introduces the Second Brain — a persistent, structured memory system backed by SQLite with full-text search — alongside fundamental changes to how Mercury stores data and renders output.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Type these during a conversation — they don't consume API tokens. Work on both
 |---------|----------|
 | **CLI** | Readline prompt, arrow-key command menus, real-time text streaming with markdown re-rendering, permission mode picker |
 | **Telegram** | HTML formatting, editable streaming messages, file uploads, typing indicators, multi-user access with admin/member roles |
+| **Web Panel** | Browser-based chat, status dashboard, auth token support, localhost by default |
+| **Discord** | Slash commands, allowlist access control, deferred responses, minimal intents |
 
 ### Telegram Access
 
@@ -233,6 +235,7 @@ Configure multiple LLM providers. Mercury tries them in order and falls back aut
 | **OpenAI** | gpt-4o-mini | `OPENAI_API_KEY` | GPT-4o, o3, etc. |
 | **Anthropic** | claude-sonnet-4 | `ANTHROPIC_API_KEY` | Claude Sonnet, Haiku, Opus |
 | **Grok (xAI)** | grok-4 | `GROK_API_KEY` | OpenAI-compatible endpoint |
+| **Z.ai (GLM)** | glm-5.1 | `ZAI_API_KEY` | OpenAI-compatible, Coding Plan endpoint opt-in |
 | **Ollama Cloud** | gpt-oss:120b | `OLLAMA_CLOUD_API_KEY` | Remote Ollama via API |
 | **Ollama Local** | gpt-oss:20b | No key needed | Local Ollama instance |
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1,0 +1,107 @@
+# Discord Channel
+
+Use Mercury from Discord via slash commands. Secure, allowlisted, and minimal-intent.
+
+## Setup
+
+### 1. Create a Discord Application
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application** → name it (e.g., "Mercury Agent")
+3. Go to **Bot** tab → click **Add Bot**
+4. Copy the **Bot Token** (this is `DISCORD_BOT_TOKEN`)
+5. Go to **OAuth2** tab → copy **Client ID** (this is `DISCORD_CLIENT_ID`)
+
+### 2. Invite the Bot to Your Server
+
+Use this URL (replace `CLIENT_ID`):
+```
+https://discord.com/api/oauth2/authorize?client_id=CLIENT_ID&permissions=2147483648&scope=bot%20applications.commands
+```
+
+This grants minimal permissions: only slash command access.
+
+### 3. Configure Mercury
+
+Add to your `.env` or `~/.mercury/.env`:
+
+```
+DISCORD_ENABLED=true
+DISCORD_BOT_TOKEN=your-bot-token
+DISCORD_CLIENT_ID=your-client-id
+DISCORD_GUILD_ID=your-server-id
+DISCORD_ALLOWED_USER_IDS=user-id-1,user-id-2
+DISCORD_ADMIN_USER_IDS=admin-user-id
+```
+
+### 4. Start Mercury
+
+```
+mercury start
+```
+
+The bot will register slash commands and come online.
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DISCORD_ENABLED` | `false` | Enable Discord integration |
+| `DISCORD_BOT_TOKEN` | — | Bot token from Developer Portal |
+| `DISCORD_CLIENT_ID` | — | Application Client ID |
+| `DISCORD_GUILD_ID` | — | Server (guild) ID for command registration |
+| `DISCORD_ALLOWED_USER_IDS` | — | Comma-separated user IDs allowed to use bot |
+| `DISCORD_ALLOWED_CHANNEL_IDS` | — | Comma-separated channel IDs |
+| `DISCORD_ADMIN_USER_IDS` | — | Comma-separated admin user IDs |
+| `DISCORD_USE_GLOBAL_COMMANDS` | `false` | Register commands globally (slower propagation) |
+| `DISCORD_ALLOW_DMS` | `false` | Allow DM interactions |
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/mercury ask <prompt>` | Send a prompt to Mercury |
+| `/mercury status` | Show agent status (safe info only) |
+| `/mercury help` | Show available commands |
+| `/mercury budget` | Show token budget status |
+| `/mercury memory` | Show memory overview |
+| `/mercury permissions` | Show permission mode |
+
+## Access Control
+
+### User Allowlist
+- If `DISCORD_ALLOWED_USER_IDS` is set, only listed users can interact with the bot
+- If empty, only `DISCORD_ADMIN_USER_IDS` can use it
+- Admins always have access
+
+### Channel Restrictions
+- If `DISCORD_ALLOWED_CHANNEL_IDS` is set, bot only responds in those channels
+- If empty, bot responds in all channels it can see
+
+### DMs
+- Disabled by default for security
+- Enable with `DISCORD_ALLOW_DMS=true`
+
+## Security
+- **No privileged intents** — doesn't require Message Content intent
+- **Slash commands only** — no raw message parsing
+- **Allowlist enforced** — unauthorized users are silently ignored
+- **No secrets exposed** — status/info commands only show safe data
+- **Permission system** — all tool execution goes through Mercury's permission flow
+
+## Finding Your Discord IDs
+
+Enable Developer Mode in Discord (Settings → Advanced → Developer Mode), then:
+- **User ID**: Right-click a user → Copy ID
+- **Channel ID**: Right-click a channel → Copy ID
+- **Guild ID**: Right-click server name → Copy ID
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Bot doesn't come online | Check `DISCORD_BOT_TOKEN` is correct |
+| Commands not appearing | Check `DISCORD_CLIENT_ID` and `DISCORD_GUILD_ID`; global commands take up to 1 hour |
+| "Interaction failed" | Check Mercury logs for errors |
+| Bot ignores messages | Verify user ID is in `DISCORD_ALLOWED_USER_IDS` or is an admin |
+| Can't use in DMs | Set `DISCORD_ALLOW_DMS=true` |

--- a/docs/channels/web-panel.md
+++ b/docs/channels/web-panel.md
@@ -1,0 +1,85 @@
+# Web Panel Channel
+
+A lightweight, browser-based interface for Mercury. No frameworks, no database — just Node.js built-in HTTP and a clean HTML interface.
+
+## Features
+
+- **Status dashboard** — see provider, budget, channels at a glance
+- **Chat interface** — send prompts and receive responses
+- **Command access** — use `/help`, `/status`, `/budget` from the browser
+- **Auth support** — optional token-based authentication for remote access
+- **Zero dependencies** — built on Node.js `node:http`
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WEB_PANEL_ENABLED` | `false` | Enable the web panel |
+| `WEB_PANEL_HOST` | `127.0.0.1` | Bind host (localhost by default) |
+| `WEB_PANEL_PORT` | `3977` | Port number |
+| `WEB_PANEL_AUTH_TOKEN` | — | Bearer token for API authentication |
+| `WEB_PANEL_ALLOW_REMOTE` | `false` | Allow remote access without auth |
+
+## Quick Start
+
+```
+WEB_PANEL_ENABLED=true
+```
+
+Then start Mercury:
+```
+mercury start
+```
+
+Open http://127.0.0.1:3977 in your browser.
+
+## Security Model
+
+### Localhost (default)
+By default, the panel binds to `127.0.0.1` — only accessible from the same machine. No auth required for local access.
+
+### LAN/WAN Access
+To make the panel accessible from other devices:
+
+```
+WEB_PANEL_HOST=0.0.0.0
+WEB_PANEL_AUTH_TOKEN=your-secret-token-here
+```
+
+**Important safety rules:**
+- If `WEB_PANEL_HOST=0.0.0.0` and no `WEB_PANEL_AUTH_TOKEN` is set, the panel **will not start** unless `WEB_PANEL_ALLOW_REMOTE=true`
+- Setting `WEB_PANEL_ALLOW_REMOTE=true` without a token logs a strong warning
+- Always use HTTPS in production (use a reverse proxy like nginx/Caddy)
+
+### Auth Token
+When `WEB_PANEL_AUTH_TOKEN` is set, all API requests must include:
+```
+Authorization: Bearer your-secret-token-here
+```
+
+The browser panel will prompt for the token on first load.
+
+### What's Protected
+- All tool execution goes through Mercury's existing permission system
+- No direct shell, file read/write, or admin operations from the panel
+- Rate limited to 60 requests/minute per IP
+- Request body limited to 1MB
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | Web panel HTML |
+| `GET` | `/api/status` | Safe status info |
+| `POST` | `/api/chat` | Send a message |
+| `GET` | `/api/help` | Help text |
+| `POST` | `/api/command` | Execute slash command |
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Panel doesn't start | Check `WEB_PANEL_ENABLED=true` and logs |
+| Can't access remotely | Set `WEB_PANEL_HOST=0.0.0.0` and configure auth |
+| Auth fails | Verify `WEB_PANEL_AUTH_TOKEN` matches in request header |
+| Port in use | Change `WEB_PANEL_PORT` to a different value |

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -1,0 +1,96 @@
+# Z.ai (GLM) Provider
+
+Z.ai provides OpenAI-compatible API access to GLM language models, including the GLM Coding Plan for coding-focused tasks.
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ZAI_API_KEY` | — | Your Z.ai API key (required) |
+| `ZAI_BASE_URL` | `https://api.z.ai/api/paas/v4` | General API endpoint |
+| `ZAI_MODEL` | `glm-5.1` | Model to use |
+| `ZAI_ENABLED` | `true` | Enable/disable provider |
+| `ZAI_CODING_PLAN_ENABLED` | `false` | Opt into GLM Coding Plan endpoint |
+| `ZAI_CODING_PLAN_BASE_URL` | `https://api.z.ai/api/coding/paas/v4` | Coding Plan endpoint |
+
+## Setup
+
+### Via Setup Wizard
+Run `mercury doctor` and select **Z.ai (GLM)** from the provider list.
+
+### Via Environment Variables
+Add to your `.env` or `~/.mercury/.env`:
+
+```
+ZAI_API_KEY=your-api-key-here
+ZAI_MODEL=glm-5.1
+DEFAULT_PROVIDER=zai
+```
+
+## Supported Models
+
+| Model | Description |
+|-------|-------------|
+| `glm-5.1` | Latest GLM model (recommended) |
+| `glm-5` | GLM 5 series |
+| `glm-4-plus` | GLM 4 enhanced |
+| `glm-4-air` | GLM 4 lightweight |
+| `glm-4-flash` | GLM 4 fast inference |
+| `glm-4-long` | GLM 4 extended context |
+| `glm-4` | GLM 4 base |
+
+The setup wizard auto-fetches available models from your Z.ai account.
+
+## GLM Coding Plan
+
+The GLM Coding Plan provides benefits for coding-related tasks through a dedicated endpoint.
+
+### Enabling
+
+```
+env
+ZAI_CODING_PLAN_ENABLED=true
+```
+
+### ⚠️ Compliance Notice
+
+> **Important**: GLM Coding Plan benefits are limited to officially supported tools and products.
+> By enabling `ZAI_CODING_PLAN_ENABLED=true`, you acknowledge that:
+> - You are responsible for ensuring your usage complies with your Z.ai plan terms.
+> - Mercury is **not** an officially supported product of Z.ai unless explicitly verified.
+> - You should review Z.ai's terms of service for the Coding Plan before use.
+> - The general endpoint (`ZAI_BASE_URL`) is used by default and is recommended unless you have an active Coding Plan subscription.
+
+### How it works
+
+When `ZAI_CODING_PLAN_ENABLED=true`:
+- Mercury uses `https://api.z.ai/api/coding/paas/v4` instead of the general endpoint
+- All requests are routed through the Coding Plan endpoint
+- Model selection and behavior remain the same
+
+When `ZAI_CODING_PLAN_ENABLED=false` (default):
+- Mercury uses `https://api.z.ai/api/paas/v4` (general endpoint)
+- Standard API access and pricing applies
+
+## Architecture
+
+Z.ai uses Mercury's OpenAI-compatible provider path (`OpenAICompatProvider`), which leverages:
+- `@ai-sdk/openai` for the API client
+- Vercel AI SDK (`ai` package) for `generateText` and `streamText`
+- Bearer token authentication
+
+No additional dependencies are required.
+
+## Security
+- API keys are never logged or exposed in responses
+- Keys are validated during setup (must look like a real token)
+- Keys are stored in `~/.mercury/.env` with standard file permissions
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "No LLM providers available" | Set `ZAI_API_KEY` in your environment |
+| Model not found | Check available models with `mercury doctor` |
+| Coding Plan errors | Verify your Coding Plan subscription and terms |
+| Connection refused | Check network access to `api.z.ai` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@ai-sdk/openai": "^1.3.0",
         "@grammyjs/auto-retry": "^2.0.2",
         "ai": "^4.3.0",
-        "better-sqlite3": "^12.9.0",
         "chalk": "^5.4.0",
         "commander": "^12.1.0",
         "dotenv": "^16.4.7",
@@ -39,7 +38,11 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.9.0",
+        "discord.js": "^14.18.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -136,6 +139,155 @@
       },
       "peerDependencies": {
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -946,6 +1098,42 @@
         "win32"
       ]
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -986,7 +1174,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1011,6 +1199,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1121,6 +1319,17 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1216,6 +1425,7 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -1229,6 +1439,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -1238,6 +1449,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1263,6 +1475,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1347,7 +1560,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -1399,6 +1613,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -1423,6 +1638,7 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1440,6 +1656,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1448,6 +1665,44 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
       "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.47",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
+      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.26.3",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.3.tgz",
+      "integrity": "sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -1465,6 +1720,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1538,6 +1794,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1550,6 +1807,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1572,7 +1836,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
@@ -1589,7 +1854,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1609,7 +1875,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/grammy": {
       "version": "1.42.0",
@@ -1643,19 +1910,22 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -1728,6 +1998,20 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1745,6 +2029,13 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1771,6 +2062,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -1783,6 +2075,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1791,7 +2084,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -1842,13 +2136,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1930,6 +2226,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2103,6 +2400,7 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -2144,6 +2442,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2159,6 +2458,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -2186,6 +2486,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2287,7 +2588,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -2307,6 +2609,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2338,7 +2641,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -2359,6 +2663,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -2416,6 +2721,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -2425,6 +2731,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2495,6 +2802,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -2507,6 +2815,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -2633,6 +2942,20 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tsup": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
@@ -2690,6 +3013,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -2716,11 +3040,21 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -2734,7 +3068,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -3403,7 +3738,30 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.3",
@@ -3492,6 +3850,101 @@
         "@ai-sdk/provider": "1.1.3",
         "@ai-sdk/provider-utils": "2.2.8",
         "zod-to-json-schema": "^3.24.1"
+      }
+    },
+    "@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "optional": true,
+      "requires": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      }
+    },
+    "@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "optional": true
+    },
+    "@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "optional": true,
+      "requires": {
+        "discord-api-types": "^0.38.33"
+      }
+    },
+    "@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "optional": true,
+      "requires": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+          "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+          "optional": true
+        },
+        "@sapphire/snowflake": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+          "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+          "optional": true
+        }
+      }
+    },
+    "@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "optional": true,
+      "requires": {
+        "discord-api-types": "^0.38.33"
+      }
+    },
+    "@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "optional": true,
+      "requires": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+          "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+          "optional": true
+        }
       }
     },
     "@esbuild/aix-ppc64": {
@@ -3906,6 +4359,28 @@
       "dev": true,
       "optional": true
     },
+    "@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "optional": true
+    },
+    "@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "optional": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      }
+    },
+    "@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "optional": true
+    },
     "@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -3946,7 +4421,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "undici-types": "~6.21.0"
       }
@@ -3971,6 +4446,15 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@vitest/expect": {
@@ -4048,6 +4532,12 @@
         "tinyrainbow": "^2.0.0"
       }
     },
+    "@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "optional": true
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4101,6 +4591,7 @@
       "version": "12.9.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -4110,6 +4601,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -4118,6 +4610,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "optional": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4128,6 +4621,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "optional": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -4184,7 +4678,8 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "optional": true
     },
     "commander": {
       "version": "12.1.0",
@@ -4221,6 +4716,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "optional": true,
       "requires": {
         "mimic-response": "^3.1.0"
       }
@@ -4234,7 +4730,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true
     },
     "dequal": {
       "version": "2.0.3",
@@ -4244,12 +4741,40 @@
     "detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "optional": true
     },
     "diff-match-patch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
       "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+    },
+    "discord-api-types": {
+      "version": "0.38.47",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
+      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
+      "optional": true
+    },
+    "discord.js": {
+      "version": "14.26.3",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.3.tgz",
+      "integrity": "sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==",
+      "optional": true,
+      "requires": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      }
     },
     "dotenv": {
       "version": "16.6.1",
@@ -4260,6 +4785,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "optional": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -4321,13 +4847,20 @@
     "expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "optional": true
     },
     "expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "optional": true
     },
     "fdir": {
       "version": "6.5.0",
@@ -4339,7 +4872,8 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fix-dts-default-cjs-exports": {
       "version": "1.0.1",
@@ -4355,7 +4889,8 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "optional": true
     },
     "fsevents": {
       "version": "2.3.3",
@@ -4367,7 +4902,8 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "optional": true
     },
     "grammy": {
       "version": "1.42.0",
@@ -4383,17 +4919,20 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "optional": true
     },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
     },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "optional": true
     },
     "joycon": {
       "version": "3.1.1",
@@ -4448,6 +4987,18 @@
       "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
       "dev": true
     },
+    "lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "optional": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "optional": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4462,6 +5013,12 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true
+    },
+    "magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "optional": true
     },
     "magic-string": {
       "version": "0.30.21",
@@ -4480,17 +5037,20 @@
     "mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "optional": true
     },
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "optional": true
     },
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "optional": true
     },
     "mlly": {
       "version": "1.8.2",
@@ -4528,12 +5088,14 @@
     "napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "optional": true
     },
     "node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "optional": true,
       "requires": {
         "semver": "^7.3.5"
       }
@@ -4579,6 +5141,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "optional": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4684,6 +5247,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "optional": true,
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -4708,6 +5272,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4722,6 +5287,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -4742,6 +5308,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "optional": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4803,7 +5370,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "optional": true
     },
     "safe-stable-stringify": {
       "version": "2.5.0",
@@ -4818,7 +5386,8 @@
     "semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "optional": true
     },
     "siginfo": {
       "version": "2.0.0",
@@ -4829,12 +5398,14 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "optional": true
     },
     "simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "optional": true,
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -4882,6 +5453,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -4889,7 +5461,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "optional": true
     },
     "strip-literal": {
       "version": "3.1.0",
@@ -4944,6 +5517,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "optional": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -4955,6 +5529,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "optional": true,
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5051,6 +5626,18 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "optional": true
+    },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "optional": true
+    },
     "tsup": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
@@ -5080,6 +5667,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -5096,11 +5684,17 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true
     },
+    "undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "optional": true
+    },
     "undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "devOptional": true
     },
     "use-sync-external-store": {
       "version": "1.6.0",
@@ -5111,7 +5705,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "optional": true
     },
     "uuid": {
       "version": "8.3.2",
@@ -5422,7 +6017,15 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "optional": true
+    },
+    "ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "optional": true,
+      "requires": {}
     },
     "yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "zod": "^3.25.76"
   },
   "optionalDependencies": {
-    "better-sqlite3": "^12.9.0"
+    "better-sqlite3": "^12.9.0",
+    "discord.js": "^14.18.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -7,6 +7,8 @@ import {
   EmbedBuilder,
   type Interaction,
   type ChatInputCommandInteraction,
+  type SlashCommandSubcommandBuilder,
+  type SlashCommandStringOption,
   MessageFlags,
 } from 'discord.js';
 import { BaseChannel } from './base.js';
@@ -70,7 +72,7 @@ export class DiscordChannel extends BaseChannel {
       }
     });
 
-    this.client.on('error', (err) => {
+    this.client.on('error', (err: Error) => {
       logger.error({ err }, 'Discord client error');
     });
 
@@ -169,19 +171,19 @@ export class DiscordChannel extends BaseChannel {
       new SlashCommandBuilder()
         .setName('mercury')
         .setDescription('Mercury Agent commands')
-        .addSubcommand((sub) =>
+        .addSubcommand((sub: SlashCommandSubcommandBuilder) =>
           sub
             .setName('ask')
             .setDescription('Send a prompt to Mercury')
-            .addStringOption((opt) =>
+            .addStringOption((opt: SlashCommandStringOption) =>
               opt.setName('prompt').setDescription('Your prompt').setRequired(true)
             )
         )
-        .addSubcommand((sub) => sub.setName('status').setDescription('Show Mercury status'))
-        .addSubcommand((sub) => sub.setName('help').setDescription('Show available commands'))
-        .addSubcommand((sub) => sub.setName('budget').setDescription('Show token budget'))
-        .addSubcommand((sub) => sub.setName('memory').setDescription('Show memory overview'))
-        .addSubcommand((sub) =>
+        .addSubcommand((sub: SlashCommandSubcommandBuilder) => sub.setName('status').setDescription('Show Mercury status'))
+        .addSubcommand((sub: SlashCommandSubcommandBuilder) => sub.setName('help').setDescription('Show available commands'))
+        .addSubcommand((sub: SlashCommandSubcommandBuilder) => sub.setName('budget').setDescription('Show token budget'))
+        .addSubcommand((sub: SlashCommandSubcommandBuilder) => sub.setName('memory').setDescription('Show memory overview'))
+        .addSubcommand((sub: SlashCommandSubcommandBuilder) =>
           sub.setName('permissions').setDescription('Show permission mode')
         ),
     ].map((c) => c.toJSON());

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,0 +1,342 @@
+import {
+  Client,
+  GatewayIntentBits,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+  EmbedBuilder,
+  type Interaction,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+} from 'discord.js';
+import { BaseChannel } from './base.js';
+import type { ChannelMessage } from '../types/channel.js';
+import type { MercuryConfig } from '../utils/config.js';
+import { logger } from '../utils/logger.js';
+
+const DISCORD_MAX_CONTENT = 2000;
+
+interface PendingInteraction {
+  resolve: (text: string) => void;
+  reject: (err: Error) => void;
+  interaction: ChatInputCommandInteraction;
+}
+
+export class DiscordChannel extends BaseChannel {
+  readonly type = 'discord' as const;
+  private client: Client | null = null;
+  private config: MercuryConfig;
+  private pendingInteractions: Map<string, PendingInteraction> = new Map();
+  private chatCommandContext?: import('../capabilities/registry.js').ChatCommandContext;
+
+  constructor(config: MercuryConfig) {
+    super();
+    this.config = config;
+  }
+
+  setChatCommandContext(ctx: import('../capabilities/registry.js').ChatCommandContext): void {
+    this.chatCommandContext = ctx;
+  }
+
+  async start(): Promise<void> {
+    const dc = this.config.channels.discord;
+    if (!dc || !dc.enabled || !dc.botToken) {
+      logger.info('Discord channel disabled or missing token — skipping');
+      return;
+    }
+
+    if (!dc.clientId) {
+      logger.error('Discord: DISCORD_CLIENT_ID is required for slash command registration');
+      return;
+    }
+
+    this.client = new Client({
+      intents: [
+        GatewayIntentBits.Guilds,
+      ],
+    });
+
+    this.client.once('ready', async () => {
+      logger.info('Discord bot connected and ready');
+      await this.registerCommands();
+      this.ready = true;
+    });
+
+    this.client.on('interactionCreate', async (interaction: Interaction) => {
+      try {
+        await this.handleInteraction(interaction);
+      } catch (err) {
+        logger.error({ err }, 'Discord interaction error');
+      }
+    });
+
+    this.client.on('error', (err) => {
+      logger.error({ err }, 'Discord client error');
+    });
+
+    try {
+      await this.client.login(dc.botToken);
+    } catch (err: any) {
+      logger.error({ err: err?.message || err }, 'Discord login failed');
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.client) {
+      this.client.destroy();
+      this.client = null;
+    }
+    this.ready = false;
+    logger.info('Discord bot stopped');
+  }
+
+  async send(content: string, targetId?: string, elapsedMs?: number): Promise<void> {
+    if (!targetId || !this.client) return;
+
+    const pending = this.pendingInteractions.get(targetId);
+    if (pending) {
+      const timeSuffix = elapsedMs != null ? `\n⏱ ${(elapsedMs / 1000).toFixed(1)}s` : '';
+      const fullContent = content + timeSuffix;
+      const chunks = this.splitForDiscord(fullContent);
+
+      try {
+        await pending.interaction.editReply(chunks[0] || '(empty response)');
+        for (let i = 1; i < chunks.length; i++) {
+          await pending.interaction.followUp({ content: chunks[i] });
+        }
+      } catch (err: any) {
+        logger.warn({ err: err?.message }, 'Discord reply failed');
+      }
+
+      pending.resolve(content);
+      this.pendingInteractions.delete(targetId);
+    }
+  }
+
+  async sendFile(_filePath: string, _targetId?: string): Promise<void> {}
+
+  async stream(content: AsyncIterable<string>, targetId?: string): Promise<string> {
+    let full = '';
+    for await (const chunk of content) {
+      full += chunk;
+    }
+    await this.send(full, targetId);
+    return full;
+  }
+
+  async typing(_targetId?: string): Promise<void> {}
+
+  async askToContinue(_question: string, _targetId?: string): Promise<boolean> {
+    return false;
+  }
+
+  private isAllowed(userId: string): boolean {
+    const dc = this.config.channels.discord;
+    if (!dc) return false;
+    if (this.isAdmin(userId)) return true;
+    if (dc.allowedUserIds.length === 0) return false;
+    return dc.allowedUserIds.includes(userId);
+  }
+
+  private isAdmin(userId: string): boolean {
+    const dc = this.config.channels.discord;
+    if (!dc) return false;
+    return dc.adminUserIds.includes(userId);
+  }
+
+  private splitForDiscord(text: string, maxLen = DISCORD_MAX_CONTENT): string[] {
+    if (text.length <= maxLen) return [text];
+    const chunks: string[] = [];
+    let remaining = text;
+    while (remaining.length > 0) {
+      if (remaining.length <= maxLen) {
+        chunks.push(remaining);
+        break;
+      }
+      let splitAt = remaining.lastIndexOf('\n', maxLen);
+      if (splitAt < maxLen * 0.3) splitAt = maxLen;
+      chunks.push(remaining.slice(0, splitAt));
+      remaining = remaining.slice(splitAt);
+    }
+    return chunks;
+  }
+
+  private async registerCommands(): Promise<void> {
+    const dc = this.config.channels.discord;
+    if (!dc || !this.client) return;
+
+    const commands = [
+      new SlashCommandBuilder()
+        .setName('mercury')
+        .setDescription('Mercury Agent commands')
+        .addSubcommand((sub) =>
+          sub
+            .setName('ask')
+            .setDescription('Send a prompt to Mercury')
+            .addStringOption((opt) =>
+              opt.setName('prompt').setDescription('Your prompt').setRequired(true)
+            )
+        )
+        .addSubcommand((sub) => sub.setName('status').setDescription('Show Mercury status'))
+        .addSubcommand((sub) => sub.setName('help').setDescription('Show available commands'))
+        .addSubcommand((sub) => sub.setName('budget').setDescription('Show token budget'))
+        .addSubcommand((sub) => sub.setName('memory').setDescription('Show memory overview'))
+        .addSubcommand((sub) =>
+          sub.setName('permissions').setDescription('Show permission mode')
+        ),
+    ].map((c) => c.toJSON());
+
+    const rest = new REST({ version: '10' }).setToken(dc.botToken);
+
+    try {
+      if (dc.useGlobalCommands) {
+        await rest.put(Routes.applicationCommands(dc.clientId), { body: commands });
+        logger.info('Discord: global commands registered');
+      } else if (dc.guildId) {
+        await rest.put(
+          Routes.applicationGuildCommands(dc.clientId, dc.guildId),
+          { body: commands }
+        );
+        logger.info('Discord: guild commands registered');
+      } else {
+        logger.warn('Discord: no GUILD_ID and global commands disabled — commands not registered');
+      }
+    } catch (err: any) {
+      logger.error({ err: err?.message }, 'Discord command registration failed');
+    }
+  }
+
+  private async handleInteraction(interaction: Interaction): Promise<void> {
+    if (!interaction.isChatInputCommand()) return;
+
+    const userId = interaction.user.id;
+    if (!this.isAllowed(userId)) {
+      await interaction.reply({
+        content: 'You are not authorized to use this bot.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const dc = this.config.channels.discord;
+    if (
+      interaction.guildId &&
+      dc?.allowedChannelIds?.length &&
+      !dc.allowedChannelIds.includes(interaction.channelId ?? '')
+    ) {
+      await interaction.reply({
+        content: 'This bot is not available in this channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!interaction.guildId && !dc?.allowDms) {
+      await interaction.reply({
+        content: 'DM access is disabled.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === 'ask') {
+      await this.handleAsk(interaction);
+      return;
+    }
+
+    if (subcommand === 'status') {
+      const embed = new EmbedBuilder()
+        .setTitle(`${this.config.identity.name} — Status`)
+        .addFields(
+          { name: 'Provider', value: this.config.providers.default, inline: true },
+          { name: 'Budget', value: `${this.config.tokens.dailyBudget.toLocaleString()} tokens/day`, inline: true },
+          { name: 'Telegram', value: this.config.channels.telegram.enabled ? 'enabled' : 'disabled', inline: true },
+          { name: 'Web Panel', value: this.config.channels.webPanel.enabled ? 'enabled' : 'disabled', inline: true },
+        )
+        .setColor(0x58a6ff);
+      await interaction.reply({ embeds: [embed] });
+      return;
+    }
+
+    if (subcommand === 'help') {
+      await interaction.reply({
+        content: [
+          '**Mercury Commands:**',
+          '`/mercury ask <prompt>` — Send a prompt',
+          '`/mercury status` — Show status',
+          '`/mercury budget` — Show token budget',
+          '`/mercury memory` — Show memory overview',
+          '`/mercury permissions` — Show permission mode',
+          '`/mercury help` — This message',
+        ].join('\n'),
+      });
+      return;
+    }
+
+    if (subcommand === 'budget') {
+      const ctx = this.chatCommandContext;
+      const budget = ctx ? ctx.tokenBudget().getStatusText() : 'Budget info unavailable';
+      await interaction.reply({ content: `**Token Budget:** ${budget}` });
+      return;
+    }
+
+    if (subcommand === 'memory') {
+      const ctx = this.chatCommandContext;
+      if (!ctx) {
+        await interaction.reply({ content: 'Memory info unavailable.' });
+        return;
+      }
+      const summary = ctx.memorySummary();
+      const lines = [
+        `**Memory Overview**`,
+        `Total: ${summary.total}`,
+        `Learning: ${summary.learningPaused ? 'PAUSED' : 'ACTIVE'}`,
+      ];
+      await interaction.reply({ content: lines.join('\n') });
+      return;
+    }
+
+    if (subcommand === 'permissions') {
+      await interaction.reply({
+        content: 'Permission mode is managed per-session via the Mercury CLI or Telegram.',
+      });
+      return;
+    }
+  }
+
+  private async handleAsk(interaction: ChatInputCommandInteraction): Promise<void> {
+    const prompt = interaction.options.getString('prompt', true);
+    const channelId = `discord:${interaction.id}`;
+
+    await interaction.deferReply();
+
+    const msg: ChannelMessage = {
+      id: interaction.id,
+      channelId,
+      channelType: 'discord',
+      senderId: interaction.user.id,
+      senderName: interaction.user.username,
+      content: prompt,
+      timestamp: Date.now(),
+      metadata: { interactionId: interaction.id },
+    };
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingInteractions.delete(channelId);
+        interaction.editReply('(timeout — no response within 60s)').catch(() => {});
+        resolve();
+      }, 60_000);
+
+      this.pendingInteractions.set(channelId, {
+        resolve: () => { clearTimeout(timer); resolve(); },
+        reject: () => { clearTimeout(timer); resolve(); },
+        interaction,
+      });
+
+      this.emit(msg);
+    });
+  }
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -2,4 +2,6 @@ export { BaseChannel } from './base.js';
 export type { Channel } from './base.js';
 export { CLIChannel } from './cli.js';
 export { TelegramChannel } from './telegram.js';
+export { WebPanelChannel } from './web-panel.js';
+export { DiscordChannel } from './discord.js';
 export { ChannelRegistry } from './registry.js';

--- a/src/channels/new-channels.test.ts
+++ b/src/channels/new-channels.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { DiscordChannel } from './discord.js';
+import { WebPanelChannel } from './web-panel.js';
+
+describe('DiscordChannel access control', () => {
+  const baseConfig = () => ({
+    channels: {
+      discord: {
+        enabled: true,
+        botToken: 'test-token',
+        clientId: 'test-client-id',
+        guildId: 'test-guild-id',
+        allowedUserIds: ['user-1', 'user-2'],
+        allowedChannelIds: ['channel-1'],
+        adminUserIds: ['admin-1'],
+        useGlobalCommands: false,
+        allowDms: false,
+      },
+      telegram: { enabled: false, botToken: '', admins: [], members: [], pending: [] },
+      webPanel: { enabled: false, host: '127.0.0.1', port: 3977, authToken: '', allowRemote: false },
+    },
+    identity: { name: 'Test', owner: 'Test' },
+    providers: { default: 'deepseek' },
+    github: { username: '', email: '', defaultOwner: '', defaultRepo: '' },
+    memory: { shortTermMaxMessages: 20, secondBrain: { enabled: false, maxRecords: 50 } },
+    heartbeat: { intervalMinutes: 60 },
+    tokens: { dailyBudget: 1000000 },
+  });
+
+  it('allows users in the allowedUserIds list', () => {
+    const channel = new DiscordChannel(baseConfig() as any);
+    expect((channel as any).isAllowed('user-1')).toBe(true);
+    expect((channel as any).isAllowed('user-2')).toBe(true);
+  });
+
+  it('allows admin users even if not in allowedUserIds', () => {
+    const channel = new DiscordChannel(baseConfig() as any);
+    expect((channel as any).isAllowed('admin-1')).toBe(true);
+  });
+
+  it('rejects users not in any allowlist', () => {
+    const channel = new DiscordChannel(baseConfig() as any);
+    expect((channel as any).isAllowed('unknown-user')).toBe(false);
+  });
+
+  it('falls back to admin-only when allowedUserIds is empty', () => {
+    const cfg = baseConfig();
+    cfg.channels.discord.allowedUserIds = [];
+    const channel = new DiscordChannel(cfg as any);
+    expect((channel as any).isAllowed('admin-1')).toBe(true);
+    expect((channel as any).isAllowed('random-user')).toBe(false);
+  });
+
+  it('splits long messages to fit Discord limits', () => {
+    const channel = new DiscordChannel(baseConfig() as any);
+    const longText = 'a'.repeat(5000);
+    const chunks = (channel as any).splitForDiscord(longText, 2000);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+    }
+    expect(chunks.join('')).toBe(longText);
+  });
+
+  it('returns single chunk for short messages', () => {
+    const channel = new DiscordChannel(baseConfig() as any);
+    const chunks = (channel as any).splitForDiscord('short message', 2000);
+    expect(chunks).toEqual(['short message']);
+  });
+});
+
+describe('WebPanelChannel security', () => {
+  it('refuses to start on 0.0.0.0 without auth token and allowRemote', async () => {
+    const config = {
+      channels: {
+        webPanel: {
+          enabled: true,
+          host: '0.0.0.0',
+          port: 3977,
+          authToken: '',
+          allowRemote: false,
+        },
+        discord: { enabled: false, botToken: '', clientId: '', guildId: '', allowedUserIds: [], allowedChannelIds: [], adminUserIds: [], useGlobalCommands: false, allowDms: false },
+        telegram: { enabled: false, botToken: '', admins: [], members: [], pending: [] },
+      },
+      identity: { name: 'Test', owner: 'Test' },
+      providers: { default: 'deepseek' },
+      github: { username: '', email: '', defaultOwner: '', defaultRepo: '' },
+      memory: { shortTermMaxMessages: 20, secondBrain: { enabled: false, maxRecords: 50 } },
+      heartbeat: { intervalMinutes: 60 },
+      tokens: { dailyBudget: 1000000 },
+    };
+    const channel = new WebPanelChannel(config as any);
+    await expect(channel.start()).rejects.toThrow();
+  });
+
+  it('does not expose secrets in status response', () => {
+    const config = {
+      channels: {
+        webPanel: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 3977,
+          authToken: 'super-secret-token',
+          allowRemote: false,
+        },
+        discord: { enabled: false, botToken: '', clientId: '', guildId: '', allowedUserIds: [], allowedChannelIds: [], adminUserIds: [], useGlobalCommands: false, allowDms: false },
+        telegram: { enabled: false, botToken: 'telegram-secret', admins: [], members: [], pending: [] },
+      },
+      identity: { name: 'Test', owner: 'Test' },
+      providers: { default: 'deepseek', zai: { apiKey: 'zai-secret-key' } },
+      github: { username: '', email: '', defaultOwner: '', defaultRepo: '' },
+      memory: { shortTermMaxMessages: 20, secondBrain: { enabled: false, maxRecords: 50 } },
+      heartbeat: { intervalMinutes: 60 },
+      tokens: { dailyBudget: 1000000 },
+    };
+    const channel = new WebPanelChannel(config as any);
+    const status = (channel as any).getStatus();
+    const statusStr = JSON.stringify(status);
+    expect(statusStr).not.toContain('super-secret-token');
+    expect(statusStr).not.toContain('telegram-secret');
+    expect(statusStr).not.toContain('zai-secret-key');
+  });
+});

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -2,6 +2,8 @@ import type { Channel } from './base.js';
 import type { ChannelMessage, ChannelType } from '../types/channel.js';
 import { CLIChannel } from './cli.js';
 import { TelegramChannel } from './telegram.js';
+import { WebPanelChannel } from './web-panel.js';
+import { DiscordChannel } from './discord.js';
 import type { MercuryConfig } from '../utils/config.js';
 import { logger } from '../utils/logger.js';
 
@@ -13,6 +15,14 @@ export class ChannelRegistry {
 
     if (config.channels.telegram.enabled && config.channels.telegram.botToken) {
       this.register('telegram', new TelegramChannel(config));
+    }
+
+    if (config.channels.webPanel.enabled) {
+      this.register('web-panel', new WebPanelChannel(config));
+    }
+
+    if (config.channels.discord.enabled && config.channels.discord.botToken) {
+      this.register('discord', new DiscordChannel(config));
     }
   }
 

--- a/src/channels/web-panel.ts
+++ b/src/channels/web-panel.ts
@@ -1,0 +1,407 @@
+import * as http from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { BaseChannel } from './base.js';
+import type { ChannelMessage } from '../types/channel.js';
+import type { MercuryConfig } from '../utils/config.js';
+import { logger } from '../utils/logger.js';
+
+interface PendingResponse {
+  resolve: (text: string) => void;
+  timer: NodeJS.Timeout;
+}
+
+interface RateBucket {
+  timestamp: number;
+  count: number;
+}
+
+export class WebPanelChannel extends BaseChannel {
+  readonly type = 'web-panel' as const;
+  private server: http.Server | null = null;
+  private config: MercuryConfig;
+  private pending: Map<string, PendingResponse> = new Map();
+  private rateLimits: Map<string, RateBucket> = new Map();
+
+  constructor(config: MercuryConfig) {
+    super();
+    this.config = config;
+  }
+
+  async start(): Promise<void> {
+    const wp = this.config.channels.webPanel;
+    if (!wp || !wp.enabled) {
+      logger.info('Web panel disabled — skipping');
+      return;
+    }
+
+    const host = wp.host || '127.0.0.1';
+    const port = wp.port || 3977;
+
+    if ((host === '0.0.0.0' || host === '::') && !wp.authToken && !wp.allowRemote) {
+      logger.error('Web panel: refusing to bind 0.0.0.0 without WEB_PANEL_AUTH_TOKEN and WEB_PANEL_ALLOW_REMOTE=true');
+      throw new Error('Web panel cannot bind to all interfaces without auth token. Set WEB_PANEL_AUTH_TOKEN or WEB_PANEL_ALLOW_REMOTE=true.');
+    }
+
+    if ((host === '0.0.0.0' || host === '::') && !wp.authToken) {
+      logger.warn('⚠ Web panel bound to all interfaces WITHOUT authentication. Anyone on your network can access it.');
+    }
+
+    this.server = http.createServer((req, res) => this.handleRequest(req, res));
+
+    await new Promise<void>((resolve, reject) => {
+      this.server!.listen(port, host, () => {
+        logger.info({ host, port }, `Web panel listening on http://${host}:${port}`);
+        this.ready = true;
+        resolve();
+      });
+      this.server!.on('error', (err) => {
+        logger.error({ err }, 'Web panel failed to start');
+        reject(err);
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+    }
+    this.pending.clear();
+    this.ready = false;
+  }
+
+  async send(content: string, targetId?: string, _elapsedMs?: number): Promise<void> {
+    if (targetId && this.pending.has(targetId)) {
+      const entry = this.pending.get(targetId)!;
+      clearTimeout(entry.timer);
+      entry.resolve(content);
+      this.pending.delete(targetId);
+    }
+  }
+
+  async sendFile(_filePath: string, _targetId?: string): Promise<void> {}
+
+  async stream(content: AsyncIterable<string>, targetId?: string): Promise<string> {
+    let full = '';
+    for await (const chunk of content) {
+      full += chunk;
+    }
+    await this.send(full, targetId);
+    return full;
+  }
+
+  async typing(_targetId?: string): Promise<void> {}
+
+  async askToContinue(_question: string, _targetId?: string): Promise<boolean> {
+    return false;
+  }
+
+  private handleRequest(req: IncomingMessage, res: ServerResponse): void {
+    const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+    const pathname = url.pathname;
+
+    // Auth check for API routes
+    if (pathname.startsWith('/api/')) {
+      const wp = this.config.channels.webPanel;
+      if (wp?.authToken && !this.checkAuth(req, res, wp.authToken)) {
+        return;
+      }
+    }
+
+    const ip = req.socket.remoteAddress || '127.0.0.1';
+    if (!this.checkRateLimit(ip, res)) return;
+
+    if (req.method === 'GET' && pathname === '/') {
+      this.serveHtml(res);
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/status') {
+      this.serveJson(res, this.getStatus());
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/help') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('Commands: /help /status /budget /tools /skills /memory');
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/chat') {
+      this.handleChat(req, res);
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/command') {
+      this.handleCommand(req, res);
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+
+  private checkAuth(req: IncomingMessage, res: ServerResponse, token: string): boolean {
+    const header = (req.headers['authorization'] || '') as string;
+    if (header.startsWith('Bearer ') && header.substring(7) === token) {
+      return true;
+    }
+    res.writeHead(401, { 'Content-Type': 'text/plain', 'WWW-Authenticate': 'Bearer' });
+    res.end('Unauthorized');
+    return false;
+  }
+
+  private checkRateLimit(ip: string, res: ServerResponse): boolean {
+    const now = Date.now();
+    const bucket = this.rateLimits.get(ip);
+    if (!bucket || now - bucket.timestamp > 60_000) {
+      this.rateLimits.set(ip, { timestamp: now, count: 1 });
+      return true;
+    }
+    bucket.count++;
+    if (bucket.count > 60) {
+      res.writeHead(429, { 'Content-Type': 'text/plain' });
+      res.end('Too many requests');
+      return false;
+    }
+    return true;
+  }
+
+  private readBody(req: IncomingMessage, res: ServerResponse, maxBytes: number): Promise<string | null> {
+    return new Promise((resolve) => {
+      const chunks: Buffer[] = [];
+      let size = 0;
+      req.on('data', (chunk: Buffer) => {
+        size += chunk.length;
+        if (size > maxBytes) {
+          req.destroy();
+          res.writeHead(413, { 'Content-Type': 'text/plain' });
+          res.end('Payload too large');
+          resolve(null);
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on('end', () => {
+        resolve(Buffer.concat(chunks).toString());
+      });
+      req.on('error', () => resolve(null));
+    });
+  }
+
+  private handleChat(req: IncomingMessage, res: ServerResponse): void {
+    void (async () => {
+      const body = await this.readBody(req, res, 1_000_000);
+      if (body === null) return;
+
+      let payload: { message?: string };
+      try {
+        payload = JSON.parse(body);
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+
+      const message = payload?.message;
+      if (typeof message !== 'string' || !message.trim()) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Message is required' }));
+        return;
+      }
+
+      const requestId = `webpanel-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const channelId = `web-panel:${requestId}`;
+
+      const msg: ChannelMessage = {
+        id: requestId,
+        channelId,
+        channelType: 'web-panel',
+        senderId: 'web-user',
+        content: message,
+        timestamp: Date.now(),
+      };
+
+      this.emit(msg);
+
+      try {
+        const reply = await new Promise<string>((resolve) => {
+          const timer = setTimeout(() => {
+            this.pending.delete(channelId);
+            resolve('(timeout — no response within 30s)');
+          }, 30_000);
+          this.pending.set(channelId, { resolve, timer });
+        });
+
+        this.serveJson(res, { reply });
+      } catch {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal error' }));
+      }
+    })();
+  }
+
+  private handleCommand(req: IncomingMessage, res: ServerResponse): void {
+    void (async () => {
+      const body = await this.readBody(req, res, 1_000_000);
+      if (body === null) return;
+
+      let payload: { command?: string };
+      try {
+        payload = JSON.parse(body);
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+
+      const cmd = payload?.command || '';
+      const channelId = `web-panel:cmd-${Date.now()}`;
+
+      const msg: ChannelMessage = {
+        id: `cmd-${Date.now()}`,
+        channelId,
+        channelType: 'web-panel',
+        senderId: 'web-user',
+        content: cmd,
+        timestamp: Date.now(),
+      };
+
+      this.emit(msg);
+      this.serveJson(res, { ok: true });
+    })();
+  }
+
+  private getStatus(): Record<string, unknown> {
+    const wp = this.config.channels.webPanel;
+    return {
+      name: this.config.identity.name,
+      provider: this.config.providers.default,
+      tokenBudget: this.config.tokens.dailyBudget,
+      telegram: this.config.channels.telegram.enabled,
+      webPanel: wp?.enabled ?? false,
+      discord: this.config.channels.discord.enabled,
+    };
+  }
+
+  private serveJson(res: ServerResponse, data: unknown): void {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  }
+
+  private serveHtml(res: ServerResponse): void {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(getHtmlPage());
+  }
+}
+
+function getHtmlPage(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mercury Web Panel</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1117; color: #c9d1d9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.5; }
+  .container { max-width: 720px; margin: 0 auto; padding: 16px; }
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; margin-bottom: 12px; }
+  h1 { font-size: 1.2rem; color: #58a6ff; margin-bottom: 4px; }
+  h2 { font-size: 1rem; color: #8b949e; margin-bottom: 8px; }
+  .input-row { display: flex; gap: 8px; }
+  .input-row input { flex: 1; padding: 8px 12px; border-radius: 6px; border: 1px solid #30363d; background: #0d1117; color: #c9d1d9; font-size: 14px; outline: none; }
+  .input-row input:focus { border-color: #58a6ff; }
+  button { padding: 8px 16px; border-radius: 6px; border: none; background: #238636; color: #fff; cursor: pointer; font-size: 14px; white-space: nowrap; }
+  button:hover { background: #2ea043; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-row { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
+  .btn-sm { padding: 4px 10px; font-size: 12px; background: #30363d; }
+  .btn-sm:hover { background: #484f58; }
+  #output { white-space: pre-wrap; font-family: 'SF Mono', Consolas, monospace; font-size: 13px; min-height: 200px; max-height: 50vh; overflow-y: auto; padding: 8px; background: #0d1117; border-radius: 6px; border: 1px solid #21262d; margin-top: 8px; }
+  .status-row { display: flex; gap: 16px; flex-wrap: wrap; font-size: 13px; color: #8b949e; }
+  .status-row span { color: #58a6ff; }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="card">
+    <h1>Mercury Web Panel</h1>
+    <div class="status-row" id="status">Loading...</div>
+  </div>
+  <div class="card">
+    <h2>Chat</h2>
+    <div class="input-row">
+      <input id="msgInput" placeholder="Type a message..." autocomplete="off" />
+      <button id="sendBtn">Send</button>
+    </div>
+    <div class="btn-row">
+      <button class="btn-sm" onclick="sendCmd('/help')">Help</button>
+      <button class="btn-sm" onclick="sendCmd('/status')">Status</button>
+      <button class="btn-sm" onclick="sendCmd('/budget')">Budget</button>
+      <button class="btn-sm" onclick="sendCmd('/tools')">Tools</button>
+    </div>
+    <div id="output"></div>
+  </div>
+</div>
+<script>
+const msgInput = document.getElementById('msgInput');
+const sendBtn = document.getElementById('sendBtn');
+const output = document.getElementById('output');
+const statusEl = document.getElementById('status');
+let token = '';
+
+// Try to get auth token from prompt if needed
+(function checkAuth() {
+  const t = localStorage.getItem('mercury_token');
+  if (t) token = t;
+})();
+
+function getToken() {
+  if (!token) {
+    const t = prompt('Enter auth token (or leave empty if none):');
+    if (t) { token = t; localStorage.setItem('mercury_token', t); }
+  }
+  return token;
+}
+
+function authHeaders() {
+  return token ? { 'Authorization': 'Bearer ' + token } : {};
+}
+
+async function send(msg) {
+  output.textContent += '\\nYou: ' + msg;
+  sendBtn.disabled = true;
+  try {
+    const r = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({ message: msg })
+    });
+    if (r.status === 401) { token = ''; localStorage.removeItem('mercury_token'); output.textContent += '\\nAuth required.'; return; }
+    const d = await r.json();
+    output.textContent += '\\nMercury: ' + (d.reply || d.error || '(no response)');
+  } catch (e) {
+    output.textContent += '\\nError: ' + e.message;
+  }
+  sendBtn.disabled = false;
+  output.scrollTop = output.scrollHeight;
+}
+
+function sendCmd(cmd) { send(cmd); }
+
+sendBtn.onclick = () => { const v = msgInput.value.trim(); if (!v) return; msgInput.value = ''; send(v); };
+msgInput.onkeydown = (e) => { if (e.key === 'Enter') sendBtn.click(); };
+
+// Fetch status on load
+fetch('/api/status', { headers: authHeaders() })
+  .then(r => r.json())
+  .then(d => { statusEl.innerHTML = 'Provider: <span>' + (d.provider||'?') + '</span> · Budget: <span>' + (d.tokenBudget||0) + '</span> · Telegram: <span>' + (d.telegram?'on':'off') + '</span> · Discord: <span>' + (d.discord?'on':'off') + '</span>'; })
+  .catch(() => { statusEl.textContent = 'Status unavailable'; });
+</script>
+</body>
+</html>`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ const PROVIDER_OPTIONS: Array<{ key: ProviderName; label: string }> = [
   { key: 'grok', label: 'Grok (xAI)' },
   { key: 'ollamaCloud', label: 'Ollama Cloud' },
   { key: 'ollamaLocal', label: 'Ollama Local' },
+  { key: 'zai', label: 'Z.ai (GLM)' },
 ];
 
 function getConfiguredProviderNames(config: MercuryConfig): ProviderName[] {
@@ -239,6 +240,12 @@ function validateApiKey(provider: ProviderName, value: string): string | null {
     return looksLikeToken(value)
       ? null
       : 'Grok keys must look like a real API token: long, no spaces, and not plain text.';
+  }
+
+  if (provider === 'zai') {
+    return looksLikeToken(value)
+      ? null
+      : 'Z.ai keys must look like a real API token: long, no spaces, and not plain text.';
   }
 
   if (provider === 'ollamaCloud') {
@@ -665,6 +672,22 @@ async function configure(existingConfig?: MercuryConfig): Promise<void> {
           config.providers.ollamaLocal.baseUrl = result.baseUrl;
           config.providers.ollamaLocal.model = result.model;
           config.providers.ollamaLocal.enabled = true;
+        }
+      }
+
+      if (provider === 'zai') {
+        const mask = isReconfig && config.providers.zai.apiKey ? ` [${maskKey(config.providers.zai.apiKey)}]` : '';
+        const result = await promptApiKeyWithModelSelection(
+          config,
+          'zai',
+          'Z.ai (GLM)',
+          chalk.white(`  Z.ai API key${mask}${isReconfig ? '' : ' (Enter to skip)'}: `),
+          isReconfig,
+        );
+        if (!result.skipped && result.apiKey && result.model) {
+          config.providers.zai.apiKey = result.apiKey;
+          config.providers.zai.model = result.model;
+          config.providers.zai.enabled = true;
         }
       }
     }
@@ -1177,6 +1200,8 @@ program
     }
     console.log(`  Provider: ${chalk.white(getProviderLabel(config.providers.default))}`);
     console.log(`  Telegram: ${config.channels.telegram.enabled ? chalk.green('enabled') : chalk.dim('disabled')}`);
+    console.log(`  Web Panel: ${config.channels.webPanel.enabled ? chalk.green('enabled') : chalk.dim('disabled')}` + (config.channels.webPanel.enabled ? ` at http://${config.channels.webPanel.host}:${config.channels.webPanel.port}` : ''));
+    console.log(`  Discord: ${config.channels.discord.enabled ? chalk.green('enabled') : chalk.dim('disabled')}`);
     console.log(`  Telegram Access: ${chalk.white(getTelegramAccessSummary(config))}`);
     console.log(`  Skills:   ${skills.length > 0 ? chalk.green(skills.map(s => s.name).join(', ')) : chalk.dim('none')}`);
     console.log(`  Budget:   ${chalk.white(config.tokens.dailyBudget.toLocaleString())} tokens/day`);

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -21,6 +21,7 @@ export class ProviderRegistry {
       config.providers.grok,
       config.providers.ollamaCloud,
       config.providers.ollamaLocal,
+      config.providers.zai,
     ];
 
     for (const pc of entries) {

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -16,7 +16,7 @@ export interface TelegramPendingRequest {
   pairingCode?: string;
 }
 
-export type ChannelType = 'cli' | 'telegram' | 'internal' | 'signal' | 'discord' | 'slack' | 'whatsapp';
+export type ChannelType = 'cli' | 'telegram' | 'internal' | 'signal' | 'discord' | 'slack' | 'whatsapp' | 'web-panel';
 
 export interface ChannelMessage {
   id: string;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -52,7 +52,8 @@ export type ProviderName =
   | 'deepseek'
   | 'grok'
   | 'ollamaCloud'
-  | 'ollamaLocal';
+  | 'ollamaLocal'
+  | 'zai';
 
 export interface MercuryConfig {
   identity: {
@@ -68,6 +69,7 @@ export interface MercuryConfig {
     grok: ProviderConfig;
     ollamaCloud: ProviderConfig;
     ollamaLocal: ProviderConfig;
+    zai: ProviderConfig;
   };
   channels: {
     telegram: {
@@ -82,6 +84,24 @@ export interface MercuryConfig {
       pairedUserId?: number;
       pairedChatId?: number;
       pairedUsername?: string;
+    };
+    webPanel: {
+      enabled: boolean;
+      host: string;
+      port: number;
+      authToken: string;
+      allowRemote: boolean;
+    };
+    discord: {
+      enabled: boolean;
+      botToken: string;
+      clientId: string;
+      guildId: string;
+      allowedUserIds: string[];
+      allowedChannelIds: string[];
+      adminUserIds: string[];
+      useGlobalCommands: boolean;
+      allowDms: boolean;
     };
   };
   github: {
@@ -173,6 +193,15 @@ export function getDefaultConfig(): MercuryConfig {
         model: getEnv('OLLAMA_LOCAL_MODEL', 'gpt-oss:20b'),
         enabled: getEnvBool('OLLAMA_LOCAL_ENABLED', false),
       },
+      zai: {
+        name: 'zai',
+        apiKey: getEnv('ZAI_API_KEY', ''),
+        baseUrl: getEnv('ZAI_CODING_PLAN_ENABLED', 'false') === 'true'
+          ? getEnv('ZAI_CODING_PLAN_BASE_URL', 'https://api.z.ai/api/coding/paas/v4')
+          : getEnv('ZAI_BASE_URL', 'https://api.z.ai/api/paas/v4'),
+        model: getEnv('ZAI_MODEL', 'glm-5.1'),
+        enabled: getEnvBool('ZAI_ENABLED', true),
+      },
     },
     channels: {
       telegram: {
@@ -187,6 +216,24 @@ export function getDefaultConfig(): MercuryConfig {
         admins: [],
         members: [],
         pending: [],
+      },
+      webPanel: {
+        enabled: getEnvBool('WEB_PANEL_ENABLED', false),
+        host: getEnv('WEB_PANEL_HOST', '127.0.0.1'),
+        port: getEnvNum('WEB_PANEL_PORT', 3977),
+        authToken: getEnv('WEB_PANEL_AUTH_TOKEN', ''),
+        allowRemote: getEnvBool('WEB_PANEL_ALLOW_REMOTE', false),
+      },
+      discord: {
+        enabled: getEnvBool('DISCORD_ENABLED', false),
+        botToken: getEnv('DISCORD_BOT_TOKEN', ''),
+        clientId: getEnv('DISCORD_CLIENT_ID', ''),
+        guildId: getEnv('DISCORD_GUILD_ID', ''),
+        allowedUserIds: getEnv('DISCORD_ALLOWED_USER_IDS', '').split(',').filter(Boolean),
+        allowedChannelIds: getEnv('DISCORD_ALLOWED_CHANNEL_IDS', '').split(',').filter(Boolean),
+        adminUserIds: getEnv('DISCORD_ADMIN_USER_IDS', '').split(',').filter(Boolean),
+        useGlobalCommands: getEnvBool('DISCORD_USE_GLOBAL_COMMANDS', false),
+        allowDms: getEnvBool('DISCORD_ALLOW_DMS', false),
       },
     },
     github: {

--- a/src/utils/new-features.test.ts
+++ b/src/utils/new-features.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultConfig } from './config.js';
+import { isProviderConfigured } from './config.js';
+
+describe('Z.ai provider configuration', () => {
+  it('includes zai in the default config', () => {
+    const config = getDefaultConfig();
+    expect(config.providers.zai).toBeDefined();
+    expect(config.providers.zai.name).toBe('zai');
+    expect(config.providers.zai.model).toBe('glm-5.1');
+    expect(config.providers.zai.enabled).toBe(true);
+  });
+
+  it('uses the general endpoint by default', () => {
+    delete process.env.ZAI_CODING_PLAN_ENABLED;
+    delete process.env.ZAI_BASE_URL;
+    const config = getDefaultConfig();
+    expect(config.providers.zai.baseUrl).toBe('https://api.z.ai/api/paas/v4');
+  });
+
+  it('switches to coding plan endpoint when ZAI_CODING_PLAN_ENABLED=true', () => {
+    process.env.ZAI_CODING_PLAN_ENABLED = 'true';
+    delete process.env.ZAI_CODING_PLAN_BASE_URL;
+    const config = getDefaultConfig();
+    expect(config.providers.zai.baseUrl).toBe('https://api.z.ai/api/coding/paas/v4');
+    delete process.env.ZAI_CODING_PLAN_ENABLED;
+  });
+
+  it('respects custom ZAI_CODING_PLAN_BASE_URL', () => {
+    process.env.ZAI_CODING_PLAN_ENABLED = 'true';
+    process.env.ZAI_CODING_PLAN_BASE_URL = 'https://custom.endpoint/v1';
+    const config = getDefaultConfig();
+    expect(config.providers.zai.baseUrl).toBe('https://custom.endpoint/v1');
+    delete process.env.ZAI_CODING_PLAN_ENABLED;
+    delete process.env.ZAI_CODING_PLAN_BASE_URL;
+  });
+
+  it('respects custom ZAI_BASE_URL when coding plan is disabled', () => {
+    process.env.ZAI_CODING_PLAN_ENABLED = 'false';
+    process.env.ZAI_BASE_URL = 'https://my-proxy.example.com/v1';
+    const config = getDefaultConfig();
+    expect(config.providers.zai.baseUrl).toBe('https://my-proxy.example.com/v1');
+    delete process.env.ZAI_CODING_PLAN_ENABLED;
+    delete process.env.ZAI_BASE_URL;
+  });
+
+  it('is not configured when API key is empty', () => {
+    delete process.env.ZAI_API_KEY;
+    const config = getDefaultConfig();
+    expect(isProviderConfigured(config.providers.zai)).toBe(false);
+  });
+
+  it('is configured when API key is set', () => {
+    process.env.ZAI_API_KEY = 'test-key-1234567890abcdef';
+    const config = getDefaultConfig();
+    expect(isProviderConfigured(config.providers.zai)).toBe(true);
+    delete process.env.ZAI_API_KEY;
+  });
+
+  it('respects ZAI_MODEL override', () => {
+    process.env.ZAI_MODEL = 'glm-4-plus';
+    const config = getDefaultConfig();
+    expect(config.providers.zai.model).toBe('glm-4-plus');
+    delete process.env.ZAI_MODEL;
+  });
+
+  it('does not leak API key in baseUrl', () => {
+    process.env.ZAI_API_KEY = 'secret-key-should-not-appear';
+    const config = getDefaultConfig();
+    expect(config.providers.zai.baseUrl).not.toContain('secret-key');
+    delete process.env.ZAI_API_KEY;
+  });
+});
+
+describe('Web Panel configuration', () => {
+  it('defaults to disabled', () => {
+    delete process.env.WEB_PANEL_ENABLED;
+    const config = getDefaultConfig();
+    expect(config.channels.webPanel.enabled).toBe(false);
+  });
+
+  it('defaults to localhost', () => {
+    delete process.env.WEB_PANEL_HOST;
+    const config = getDefaultConfig();
+    expect(config.channels.webPanel.host).toBe('127.0.0.1');
+  });
+
+  it('defaults to port 3977', () => {
+    delete process.env.WEB_PANEL_PORT;
+    const config = getDefaultConfig();
+    expect(config.channels.webPanel.port).toBe(3977);
+  });
+
+  it('defaults to empty auth token', () => {
+    delete process.env.WEB_PANEL_AUTH_TOKEN;
+    const config = getDefaultConfig();
+    expect(config.channels.webPanel.authToken).toBe('');
+  });
+
+  it('defaults to no remote access', () => {
+    delete process.env.WEB_PANEL_ALLOW_REMOTE;
+    const config = getDefaultConfig();
+    expect(config.channels.webPanel.allowRemote).toBe(false);
+  });
+});
+
+describe('Discord configuration', () => {
+  it('defaults to disabled', () => {
+    delete process.env.DISCORD_ENABLED;
+    const config = getDefaultConfig();
+    expect(config.channels.discord.enabled).toBe(false);
+  });
+
+  it('defaults to empty bot token', () => {
+    delete process.env.DISCORD_BOT_TOKEN;
+    const config = getDefaultConfig();
+    expect(config.channels.discord.botToken).toBe('');
+  });
+
+  it('defaults to empty allowlists', () => {
+    delete process.env.DISCORD_ALLOWED_USER_IDS;
+    delete process.env.DISCORD_ALLOWED_CHANNEL_IDS;
+    delete process.env.DISCORD_ADMIN_USER_IDS;
+    const config = getDefaultConfig();
+    expect(config.channels.discord.allowedUserIds).toEqual([]);
+    expect(config.channels.discord.allowedChannelIds).toEqual([]);
+    expect(config.channels.discord.adminUserIds).toEqual([]);
+  });
+
+  it('parses comma-separated user IDs', () => {
+    process.env.DISCORD_ALLOWED_USER_IDS = '123,456,789';
+    const config = getDefaultConfig();
+    expect(config.channels.discord.allowedUserIds).toEqual(['123', '456', '789']);
+    delete process.env.DISCORD_ALLOWED_USER_IDS;
+  });
+
+  it('defaults DMs to disabled', () => {
+    delete process.env.DISCORD_ALLOW_DMS;
+    const config = getDefaultConfig();
+    expect(config.channels.discord.allowDms).toBe(false);
+  });
+
+  it('defaults global commands to disabled', () => {
+    delete process.env.DISCORD_USE_GLOBAL_COMMANDS;
+    const config = getDefaultConfig();
+    expect(config.channels.discord.useGlobalCommands).toBe(false);
+  });
+});

--- a/src/utils/provider-models.ts
+++ b/src/utils/provider-models.ts
@@ -51,6 +51,16 @@ const OLLAMA_LOCAL_PREFERRED_MODELS = [
   'gpt-oss:120b',
 ] as const;
 
+const ZAI_PREFERRED_MODELS = [
+  'glm-5.1',
+  'glm-5',
+  'glm-4-plus',
+  'glm-4-air',
+  'glm-4-flash',
+  'glm-4-long',
+  'glm-4',
+] as const;
+
 export class ProviderModelFetchError extends Error {
   constructor(message: string) {
     super(message);
@@ -154,6 +164,7 @@ function chooseRecommendedModel(
     grok: GROK_PREFERRED_MODELS,
     ollamaCloud: OLLAMA_CLOUD_PREFERRED_MODELS,
     ollamaLocal: OLLAMA_LOCAL_PREFERRED_MODELS,
+    zai: ZAI_PREFERRED_MODELS,
   };
 
   for (const candidate of preferredByProvider[provider]) {
@@ -187,6 +198,7 @@ export function buildModelCatalog(
     grok: GROK_PREFERRED_MODELS,
     ollamaCloud: OLLAMA_CLOUD_PREFERRED_MODELS,
     ollamaLocal: OLLAMA_LOCAL_PREFERRED_MODELS,
+    zai: ZAI_PREFERRED_MODELS,
   };
 
   const withoutRecommended = filtered.filter((model) => model !== recommendedModel);
@@ -206,7 +218,7 @@ async function fetchOpenAICompatModels(provider: ProviderName, config: ProviderC
         Authorization: `Bearer ${config.apiKey}`,
       },
     },
-    `Mercury could not fetch models for this ${provider === 'grok' ? 'Grok' : provider === 'deepseek' ? 'DeepSeek' : 'OpenAI'} key. Please re-enter it.`,
+    `Mercury could not fetch models for this ${provider === 'grok' ? 'Grok' : provider === 'deepseek' ? 'DeepSeek' : provider === 'zai' ? 'Z.ai' : 'OpenAI'} key. Please re-enter it.`,
   );
 
   const ids = (data.data ?? [])

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     "ink",
     "grammy",
     "better-sqlite3",
+    "discord.js",
   ],
 });


### PR DESCRIPTION
## Summary

This PR adds three new features to Mercury Agent:

1. **Z.ai (GLM) provider** — First-class support for Z.ai's OpenAI-compatible API with opt-in GLM Coding Plan endpoint
2. **Lightweight web panel** — Browser-based chat interface using only Node.js built-in `node:http`
3. **Discord channel** — Slash command bot with allowlist access control and minimal Gateway intents

## What changed

### Z.ai Provider (`feat(providers)`)
- Added `zai` to `ProviderName` union and `MercuryConfig.providers`
- Uses existing `OpenAICompatProvider` (OpenAI-compatible, no new deps)
- Defaults to general endpoint (`https://api.z.ai/api/paas/v4`)
- Coding Plan endpoint opt-in via `ZAI_CODING_PLAN_ENABLED=true`
- Added GLM preferred model list for setup wizard model selection
- Added Z.ai API key validation and setup flow in `mercury doctor`

### Web Panel (`feat(web)`)
- `src/channels/web-panel.ts` — HTTP server using `node:http`, zero external deps
- Default disabled (`WEB_PANEL_ENABLED=false`)
- Default localhost-only (`127.0.0.1:3977`)
- Optional auth token for remote access
- **Refuses** to bind `0.0.0.0` without auth token unless `WEB_PANEL_ALLOW_REMOTE=true`
- Rate limiting (60 req/min per IP), 1MB request size limit
- Clean dark-theme HTML UI with status card, chat input, command buttons

### Discord (`feat(discord)`)
- `src/channels/discord.ts` — Slash command bot via `discord.js` (minimal intents: Guilds only)
- Commands: `/mercury ask`, `status`, `help`, `budget`, `memory`, `permissions`
- Allowlist-based access: `DISCORD_ALLOWED_USER_IDS`, `DISCORD_ADMIN_USER_IDS`
- Channel restrictions: `DISCORD_ALLOWED_CHANNEL_IDS`
- DMs disabled by default
- Deferred responses for long-running tasks
- Response splitting for Discord's 2000-char limit

### Documentation (`docs`)
- `docs/providers/zai.md` — Setup, models, Coding Plan compliance notice
- `docs/channels/web-panel.md` — Setup, security model, API endpoints
- `docs/channels/discord.md` — Bot creation, slash commands, access control
- README updated: provider table + channels table
- `.env.example` updated with all new config vars
- `CHANGELOG.md` updated with `[Unreleased]` section

### Tests (`test`)
- 28 new tests covering:
  - Z.ai config, base URL switching, Coding Plan toggle, missing key, no secret leakage
  - Web Panel defaults, localhost, auth token, no secrets in status
  - Discord allowlist checks, admin-only fallback, message splitting
  - Web Panel refuses `0.0.0.0` without auth

## Why

- **Z.ai**: GLM models are increasingly popular; OpenAI-compatible makes integration trivial
- **Web panel**: Not everyone wants Telegram; a browser panel is the lowest-friction alternative
- **Discord**: Teams already on Discord can interact with Mercury without switching tools

## How to test

```bash
# 1. Install and build
npm install && npm run build

# 2. Run tests
npm test          # 48 tests should pass

# 3. Typecheck
npm run typecheck  # Zero errors

# 4. Test Z.ai provider
ZAI_API_KEY=your-key mercury doctor
# Select "Z.ai (GLM)" from provider list

# 5. Test web panel
WEB_PANEL_ENABLED=true mercury start
# Open http://127.0.0.1:3977

# 6. Test Discord (requires bot token)
DISCORD_ENABLED=true DISCORD_BOT_TOKEN=xxx DISCORD_CLIENT_ID=xxx DISCORD_GUILD_ID=xxx mercury start
```

## Security considerations

- **No secrets in logs, tests, or responses** — verified by tests
- **Web panel defaults to localhost** — remote access requires explicit opt-in + auth token
- **Discord allowlists enforced** — unauthorized users silently ignored
- **Z.ai Coding Plan is opt-in** — default uses general endpoint
- **No new shell/file operations exposed** — all agent work routed through Mercury's permission system

## Z.ai Coding Plan compliance note

> ⚠️ GLM Coding Plan benefits are limited to officially supported tools and products. Mercury is **not** an officially supported product of Z.ai unless explicitly verified. The Coding Plan endpoint is opt-in via `ZAI_CODING_PLAN_ENABLED=true`. Users are responsible for ensuring their usage complies with their Z.ai plan terms. The general endpoint (`https://api.z.ai/api/paas/v4`) is used by default.

## Files changed

| File | Change |
|------|--------|
| `src/utils/config.ts` | Add `zai` provider, `webPanel` and `discord` channel config |
| `src/providers/registry.ts` | Register Z.ai provider |
| `src/utils/provider-models.ts` | Add GLM preferred models |
| `src/types/channel.ts` | Add `'web-panel'` to ChannelType |
| `src/channels/web-panel.ts` | **New** — Web panel channel implementation |
| `src/channels/discord.ts` | **New** — Discord channel implementation |
| `src/channels/registry.ts` | Register web panel and Discord channels |
| `src/channels/index.ts` | Export new channels |
| `src/index.ts` | Z.ai setup flow, status output for new channels |
| `tsup.config.ts` | Add `discord.js` to externals |
| `.env.example` | All new environment variables |
| `README.md` | Provider + channels table updates |
| `CHANGELOG.md` | Unreleased section |
| `docs/providers/zai.md` | **New** — Z.ai documentation |
| `docs/channels/web-panel.md` | **New** — Web panel documentation |
| `docs/channels/discord.md` | **New** — Discord documentation |
| `src/utils/new-features.test.ts` | **New** — Config and provider tests |
| `src/channels/new-channels.test.ts` | **New** — Channel safety tests |

## Test results

```
✓ src/utils/provider-models.test.ts (3 tests)
✓ src/utils/telegram-access.test.ts (4 tests)
✓ src/utils/new-features.test.ts (20 tests)
✓ src/memory/user-memory.test.ts (13 tests)
✓ src/channels/new-channels.test.ts (8 tests)

Test Files  5 passed (5)
     Tests  48 passed (48)
```

## Known limitations

- Web panel does not support streaming responses (falls back to buffered)
- Discord file sending is not implemented in this initial version
- Discord slash commands can take up to 1 hour to propagate when using global commands
- Z.ai model catalog fetch depends on their `/models` endpoint availability
- `discord.js` is the only new dependency (justified: Mercury's channel model requires persistent Gateway connection)

## Checklist

- [x] Fork created
- [x] Feature branch pushed
- [x] Z.ai provider works with general endpoint
- [x] Coding Plan endpoint is opt-in and documented with compliance warning
- [x] Web panel defaults to localhost and disabled
- [x] Remote web panel requires explicit config and auth warning
- [x] Discord channel disabled by default
- [x] Discord allowlists enforced
- [x] Docs updated
- [x] `.env.example` updated
- [x] Typecheck passes
- [x] Build passes
- [x] Tests pass
- [x] PR opened and ready for review