### PR TITLE
fix: migrate DeepSeek to dedicated SDK, upgrade AI SDK v4→v6, add /ex…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,10 @@ OPENAI_MODEL=gpt-4o-mini
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-sonnet-4-20250514
 
-# DeepSeek (uses OpenAI-compatible API)
+# DeepSeek (uses dedicated DeepSeek SDK)
 DEEPSEEK_API_KEY=
 DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
-DEEPSEEK_MODEL=deepseek-chat
+DEEPSEEK_MODEL=deepseek-v4-flash
 
 # Grok / xAI (OpenAI-compatible API)
 GROK_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/anthropic": "^1.2.0",
-        "@ai-sdk/openai": "^1.3.0",
+        "@ai-sdk/anthropic": "^3.0.71",
+        "@ai-sdk/deepseek": "^2.0.29",
+        "@ai-sdk/openai": "^3.0.53",
         "@grammyjs/auto-retry": "^2.0.2",
-        "ai": "^4.3.0",
-        "better-sqlite3": "^12.9.0",
+        "ai": "^6.0.168",
         "chalk": "^5.4.0",
         "commander": "^12.1.0",
         "dotenv": "^16.4.7",
@@ -39,37 +39,191 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.9.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
-      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/deepseek": {
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.29.tgz",
+      "integrity": "sha512-cn4+xV0menm/4JKEDElnVGiUilHvi6AD4ZK/sY7DXP/Wb7Yb3Vr86NyYM6mGBE/Shk3mWHoHbzggVnF5x0uMEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/deepseek/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/deepseek/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.3.24",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
-      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -91,45 +245,6 @@
         "@ai-sdk/provider": "1.1.3",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -946,6 +1061,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -970,11 +1091,6 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
-    },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1011,6 +1127,15 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1145,28 +1270,50 @@
       }
     },
     "node_modules/ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
       },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/any-promise": {
@@ -1216,6 +1363,7 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -1229,6 +1377,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -1238,6 +1387,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1263,6 +1413,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1347,7 +1498,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -1399,6 +1551,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -1423,16 +1576,9 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1440,14 +1586,10 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -1465,6 +1607,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1533,11 +1676,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1572,7 +1725,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
@@ -1589,7 +1743,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1609,7 +1764,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/grammy": {
       "version": "1.42.0",
@@ -1643,19 +1799,22 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -1674,32 +1833,10 @@
         "base64-js": "^1.5.1"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "peer": true
-    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
-    "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      },
-      "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1726,18 +1863,6 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -1771,6 +1896,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -1783,6 +1909,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1791,7 +1918,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -1842,13 +1970,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1930,6 +2060,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2103,6 +2234,7 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -2144,6 +2276,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2159,6 +2292,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -2169,23 +2303,12 @@
         "rc": "cli.js"
       }
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2287,7 +2410,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -2307,6 +2431,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2338,7 +2463,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -2359,6 +2485,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -2416,6 +2543,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -2425,6 +2553,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2478,23 +2607,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/swr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
-      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -2507,6 +2625,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -2545,17 +2664,6 @@
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "dependencies": {
         "real-require": "^0.2.0"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -2690,6 +2798,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -2722,19 +2831,12 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -3403,7 +3505,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/yaml": {
       "version": "2.8.3",
@@ -3426,33 +3529,124 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
     }
   },
   "dependencies": {
     "@ai-sdk/anthropic": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
-      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
       "requires": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "dependencies": {
+        "@ai-sdk/provider": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+          "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+          "requires": {
+            "json-schema": "^0.4.0"
+          }
+        },
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.23",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+          "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.8",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.6"
+          }
+        }
+      }
+    },
+    "@ai-sdk/deepseek": {
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.29.tgz",
+      "integrity": "sha512-cn4+xV0menm/4JKEDElnVGiUilHvi6AD4ZK/sY7DXP/Wb7Yb3Vr86NyYM6mGBE/Shk3mWHoHbzggVnF5x0uMEA==",
+      "requires": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "dependencies": {
+        "@ai-sdk/provider": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+          "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+          "requires": {
+            "json-schema": "^0.4.0"
+          }
+        },
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.23",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+          "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.8",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.6"
+          }
+        }
+      }
+    },
+    "@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "requires": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "dependencies": {
+        "@ai-sdk/provider": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+          "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+          "requires": {
+            "json-schema": "^0.4.0"
+          }
+        },
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.23",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+          "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.8",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.6"
+          }
+        }
       }
     },
     "@ai-sdk/openai": {
-      "version": "1.3.24",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
-      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "requires": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "dependencies": {
+        "@ai-sdk/provider": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+          "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+          "requires": {
+            "json-schema": "^0.4.0"
+          }
+        },
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.23",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+          "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.8",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.6"
+          }
+        }
       }
     },
     "@ai-sdk/provider": {
@@ -3471,27 +3665,6 @@
         "@ai-sdk/provider": "1.1.3",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
-      }
-    },
-    "@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "requires": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      }
-    },
-    "@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
-      "requires": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
       }
     },
     "@esbuild/aix-ppc64": {
@@ -3906,6 +4079,11 @@
       "dev": true,
       "optional": true
     },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
     "@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -3930,11 +4108,6 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
-    },
-    "@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg=="
     },
     "@types/estree": {
       "version": "1.0.8",
@@ -3972,6 +4145,11 @@
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
+    },
+    "@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="
     },
     "@vitest/expect": {
       "version": "3.2.4",
@@ -4063,16 +4241,34 @@
       "dev": true
     },
     "ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
       "requires": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "dependencies": {
+        "@ai-sdk/provider": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+          "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+          "requires": {
+            "json-schema": "^0.4.0"
+          }
+        },
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.23",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+          "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.8",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.6"
+          }
+        }
       }
     },
     "any-promise": {
@@ -4101,6 +4297,7 @@
       "version": "12.9.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -4110,6 +4307,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -4118,6 +4316,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "optional": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4128,6 +4327,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "optional": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -4184,7 +4384,8 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "optional": true
     },
     "commander": {
       "version": "12.1.0",
@@ -4221,6 +4422,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "optional": true,
       "requires": {
         "mimic-response": "^3.1.0"
       }
@@ -4234,22 +4436,14 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-    },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true
     },
     "detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
-    },
-    "diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "optional": true
     },
     "dotenv": {
       "version": "16.6.1",
@@ -4260,6 +4454,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "optional": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -4318,10 +4513,16 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
+    "eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
+    },
     "expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "optional": true
     },
     "expect-type": {
       "version": "1.3.0",
@@ -4339,7 +4540,8 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fix-dts-default-cjs-exports": {
       "version": "1.0.1",
@@ -4355,7 +4557,8 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "optional": true
     },
     "fsevents": {
       "version": "2.3.3",
@@ -4367,7 +4570,8 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "optional": true
     },
     "grammy": {
       "version": "1.42.0",
@@ -4383,17 +4587,20 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "optional": true
     },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
     },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "optional": true
     },
     "joycon": {
       "version": "3.1.1",
@@ -4409,26 +4616,10 @@
         "base64-js": "^1.5.1"
       }
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "peer": true
-    },
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
-    "jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "requires": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      }
     },
     "lilconfig": {
       "version": "3.1.3",
@@ -4447,15 +4638,6 @@
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
       "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
       "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "loupe": {
       "version": "3.2.1",
@@ -4480,17 +4662,20 @@
     "mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "optional": true
     },
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "optional": true
     },
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "optional": true
     },
     "mlly": {
       "version": "1.8.2",
@@ -4528,12 +4713,14 @@
     "napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "optional": true
     },
     "node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "optional": true,
       "requires": {
         "semver": "^7.3.5"
       }
@@ -4579,6 +4766,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "optional": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4684,6 +4872,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "optional": true,
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -4708,6 +4897,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4722,6 +4912,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -4729,19 +4920,11 @@
         "strip-json-comments": "~2.0.1"
       }
     },
-    "react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "optional": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4803,7 +4986,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "optional": true
     },
     "safe-stable-stringify": {
       "version": "2.5.0",
@@ -4818,7 +5002,8 @@
     "semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "optional": true
     },
     "siginfo": {
       "version": "2.0.0",
@@ -4829,12 +5014,14 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "optional": true
     },
     "simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "optional": true,
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -4882,6 +5069,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -4889,7 +5077,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "optional": true
     },
     "strip-literal": {
       "version": "3.1.0",
@@ -4931,19 +5120,11 @@
         }
       }
     },
-    "swr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
-      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
-      "requires": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      }
-    },
     "tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "optional": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -4955,6 +5136,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "optional": true,
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4988,11 +5170,6 @@
       "requires": {
         "real-require": "^0.2.0"
       }
-    },
-    "throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="
     },
     "tinybench": {
       "version": "2.9.0",
@@ -5080,6 +5257,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -5102,16 +5280,11 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
-    "use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "requires": {}
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "optional": true
     },
     "uuid": {
       "version": "8.3.2",
@@ -5422,7 +5595,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "optional": true
     },
     "yaml": {
       "version": "2.8.3",
@@ -5433,12 +5607,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
-    },
-    "zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,10 +54,11 @@
     "dist"
   ],
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.2.0",
-    "@ai-sdk/openai": "^1.3.0",
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/deepseek": "^2.0.29",
+    "@ai-sdk/openai": "^3.0.53",
     "@grammyjs/auto-retry": "^2.0.2",
-    "ai": "^4.3.0",
+    "ai": "^6.0.168",
     "chalk": "^5.4.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.7",

--- a/src/capabilities/filesystem/approve-scope.ts
+++ b/src/capabilities/filesystem/approve-scope.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { resolve, isAbsolute } from 'node:path';
 import type { PermissionManager } from '../permissions.js';
@@ -6,10 +6,10 @@ import type { PermissionManager } from '../permissions.js';
 export function createApproveScopeTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'Request user approval to access a directory outside current scopes. Use this when a file tool returns a permission denied error. The user gets an approval prompt (Allow/Always/Deny buttons on Telegram, yes/always/no on CLI). "Allow" grants session-only access. "Always" persists to disk. After approval, retry the original file operation.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('The directory path to request access to'),
       mode: z.enum(['read', 'write']).describe('The access mode needed'),
-    }),
+    })),
     execute: async ({ path, mode }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
       const result = await permissions.requestScopeExternal(resolved, mode);

--- a/src/capabilities/filesystem/create-file.ts
+++ b/src/capabilities/filesystem/create-file.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname, isAbsolute } from 'node:path';
@@ -7,10 +7,10 @@ import type { PermissionManager } from '../permissions.js';
 export function createCreateFileTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'Create a new file with the given content. Also creates parent directories if needed. The path must be within a writable scope.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Absolute or relative path for the new file'),
       content: z.string().describe('The content of the new file'),
-    }),
+    })),
     execute: async ({ path, content }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
       const check = await permissions.checkFsAccess(resolved, 'write');

--- a/src/capabilities/filesystem/delete-file.ts
+++ b/src/capabilities/filesystem/delete-file.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { existsSync, unlinkSync } from 'node:fs';
 import { resolve, isAbsolute } from 'node:path';
@@ -7,9 +7,9 @@ import type { PermissionManager } from '../permissions.js';
 export function createDeleteFileTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'Delete a file. This action cannot be undone. The path must be within a writable scope. Always asks for confirmation.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Absolute or relative path to the file to delete'),
-    }),
+    })),
     execute: async ({ path }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
       const check = await permissions.checkFsAccess(resolved, 'write');

--- a/src/capabilities/filesystem/edit-file.ts
+++ b/src/capabilities/filesystem/edit-file.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, isAbsolute } from 'node:path';
@@ -7,11 +7,11 @@ import type { PermissionManager } from '../permissions.js';
 export function createEditFileTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'Edit a file by replacing an exact string match with new content. Use this instead of write_file when you only need to change part of a file. The old_string must match exactly (including whitespace and indentation). Fails if old_string is not found or found multiple times.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Absolute or relative path to the file'),
       old_string: z.string().describe('The exact text to find in the file (must match exactly)'),
       new_string: z.string().describe('The text to replace it with'),
-    }),
+    })),
     execute: async ({ path, old_string, new_string }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
 

--- a/src/capabilities/filesystem/list-dir.ts
+++ b/src/capabilities/filesystem/list-dir.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, isAbsolute, join } from 'node:path';
@@ -7,9 +7,9 @@ import type { PermissionManager } from '../permissions.js';
 export function createListDirTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'List the contents of a directory. Shows file names, types, and sizes.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Absolute or relative path to the directory'),
-    }),
+    })),
     execute: async ({ path }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
       const check = await permissions.checkFsAccess(resolved, 'read');

--- a/src/capabilities/filesystem/read-file.ts
+++ b/src/capabilities/filesystem/read-file.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve, isAbsolute } from 'node:path';
@@ -7,9 +7,9 @@ import type { PermissionManager } from '../permissions.js';
 export function createReadFileTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'Read the contents of a file. The path must be within an allowed scope.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Absolute or relative path to the file'),
-    }),
+    })),
     execute: async ({ path }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
       const check = await permissions.checkFsAccess(resolved, 'read');

--- a/src/capabilities/filesystem/send-file.ts
+++ b/src/capabilities/filesystem/send-file.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { existsSync, statSync } from 'node:fs';
 import { resolve, basename, isAbsolute } from 'node:path';
@@ -12,9 +12,9 @@ export function createSendFileTool(
   return tool({
     description:
       'Send a file to the user. On Telegram the file is uploaded as an attachment to the relevant approved recipients. On CLI the file path and size are displayed. The path must be within an allowed read scope.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Absolute or relative path to the file to send'),
-    }),
+    })),
     execute: async ({ path }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
       const check = await permissions.checkFsAccess(resolved, 'read');

--- a/src/capabilities/filesystem/write-file.ts
+++ b/src/capabilities/filesystem/write-file.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { resolve, dirname, isAbsolute } from 'node:path';
@@ -8,10 +8,10 @@ import type { PermissionManager } from '../permissions.js';
 export function createWriteFileTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'Write content to an existing file. The path must be within a writable scope.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Absolute or relative path to the file'),
       content: z.string().describe('The content to write to the file'),
-    }),
+    })),
     execute: async ({ path, content }) => {
       const resolved = isAbsolute(path) ? resolve(path) : resolve(getCwd(), path);
       const check = await permissions.checkFsAccess(resolved, 'write');

--- a/src/capabilities/git/git-add.ts
+++ b/src/capabilities/git/git-add.ts
@@ -1,13 +1,13 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 
 export function createGitAddTool(getCwd: () => string) {
   return tool({
     description: 'Add file contents to the index (staging area). Prepares files for commit.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       paths: z.array(z.string()).describe('File paths to stage'),
-    }),
+    })),
     execute: async ({ paths }) => {
       try {
         const fileArgs = paths.map(p => `"${p}"`).join(' ');

--- a/src/capabilities/git/git-commit.ts
+++ b/src/capabilities/git/git-commit.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 import { writeFileSync, unlinkSync } from 'node:fs';
@@ -9,9 +9,9 @@ const CO_AUTHOR = 'Mercury <mercury@cosmicstack.org>';
 export function createGitCommitTool(getCwd: () => string) {
   return tool({
     description: 'Record changes to the repository. Creates a new commit with staged changes. Automatically includes a Co-authored-by trailer for attribution.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       message: z.string().describe('Commit message'),
-    }),
+    })),
     execute: async ({ message }) => {
       try {
         const fullMessage = `${message}\n\nCo-authored-by: ${CO_AUTHOR}`;

--- a/src/capabilities/git/git-diff.ts
+++ b/src/capabilities/git/git-diff.ts
@@ -1,14 +1,14 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 
 export function createGitDiffTool(getCwd: () => string) {
   return tool({
     description: 'Show changes between commits, commit and working tree, etc. Shows what has been modified.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().optional().describe('File or directory to diff'),
       staged: z.boolean().optional().describe('Show staged changes (cached) instead of unstaged'),
-    }),
+    })),
     execute: async ({ path, staged }) => {
       try {
         let cmd = 'git diff';

--- a/src/capabilities/git/git-log.ts
+++ b/src/capabilities/git/git-log.ts
@@ -1,14 +1,14 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 
 export function createGitLogTool(getCwd: () => string) {
   return tool({
     description: 'Show commit logs. Returns recent commit history with hash, author, date, and message.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       count: z.number().optional().describe('Number of commits to show (default 10)'),
       path: z.string().optional().describe('File or directory to show log for'),
-    }),
+    })),
     execute: async ({ count, path }) => {
       try {
         const n = count ?? 10;

--- a/src/capabilities/git/git-push.ts
+++ b/src/capabilities/git/git-push.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 import type { PermissionManager } from '../permissions.js';
@@ -6,10 +6,10 @@ import type { PermissionManager } from '../permissions.js';
 export function createGitPushTool(permissions: PermissionManager, getCwd: () => string) {
   return tool({
     description: 'Push commits to a remote repository. This modifies a remote and requires approval.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       remote: z.string().optional().describe('Remote name (default: origin)'),
       branch: z.string().optional().describe('Branch name (default: current branch)'),
-    }),
+    })),
     execute: async ({ remote, branch }) => {
       const cmd = `git push ${remote || 'origin'} ${branch || ''}`.trim();
       const check = await permissions.checkShellCommand(cmd);

--- a/src/capabilities/git/git-status.ts
+++ b/src/capabilities/git/git-status.ts
@@ -1,13 +1,13 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 
 export function createGitStatusTool(getCwd: () => string) {
   return tool({
     description: 'Show the working tree status. Returns staged, unstaged, and untracked files.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().optional().describe('Path to check (defaults to current directory)'),
-    }),
+    })),
     execute: async ({ path }) => {
       try {
         const cmd = path ? `git -C "${path}" status --porcelain` : 'git status --porcelain';

--- a/src/capabilities/github/create-issue.ts
+++ b/src/capabilities/github/create-issue.ts
@@ -1,17 +1,17 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { githubRequest } from '../../utils/github.js';
 
 export function createCreateIssueTool() {
   return tool({
     description: 'Create a new GitHub issue in a repository. Requires GITHUB_TOKEN.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       owner: z.string().describe('Repository owner (username or org)'),
       repo: z.string().describe('Repository name'),
       title: z.string().describe('Issue title'),
       body: z.string().describe('Issue description (markdown supported)').default(''),
       labels: z.array(z.string()).describe('Label names to apply').optional(),
-    }),
+    })),
     execute: async ({ owner, repo, title, body, labels }) => {
       try {
         const payload: any = { title, body };

--- a/src/capabilities/github/create-pr.ts
+++ b/src/capabilities/github/create-pr.ts
@@ -1,11 +1,11 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { githubRequest } from '../../utils/github.js';
 
 export function createCreatePrTool() {
   return tool({
     description: 'Create a pull request on GitHub. Requires GITHUB_TOKEN to be configured.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       owner: z.string().describe('Repository owner (username or org)'),
       repo: z.string().describe('Repository name'),
       title: z.string().describe('PR title'),
@@ -13,7 +13,7 @@ export function createCreatePrTool() {
       head: z.string().describe('The branch containing the changes'),
       base: z.string().describe('The branch to merge into').default('main'),
       draft: z.boolean().describe('Create as draft PR').default(false),
-    }),
+    })),
     execute: async ({ owner, repo, title, body, head, base, draft }) => {
       try {
         const result = await githubRequest(`/repos/${owner}/${repo}/pulls`, {

--- a/src/capabilities/github/github-api.ts
+++ b/src/capabilities/github/github-api.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { githubRequest } from '../../utils/github.js';
 
@@ -41,11 +41,11 @@ Common operations you can perform:
 - Any other GitHub API v3 endpoint.
 
 IMPORTANT: When the user wants to push code or files to GitHub and git push fails (auth issues, no SSH key, etc.), use PUT /repos/{owner}/{repo}/contents/{path} to create or update files directly through the API. This bypasses local git and creates a commit with Mercury as co-author.`,
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('Full API path (e.g., /repos/owner/repo/issues or /repos/owner/repo/contents/path/to/file)'),
       method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).describe('HTTP method').default('GET'),
       body: z.string().describe('JSON body for write requests (as a JSON string)').optional(),
-    }),
+    })),
     execute: async ({ path, method, body }) => {
       try {
         let parsedBody: any;

--- a/src/capabilities/github/list-issues.ts
+++ b/src/capabilities/github/list-issues.ts
@@ -1,17 +1,17 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { githubRequest } from '../../utils/github.js';
 
 export function createListIssuesTool() {
   return tool({
     description: 'List GitHub issues for a repository. Requires GITHUB_TOKEN.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       owner: z.string().describe('Repository owner (username or org)'),
       repo: z.string().describe('Repository name'),
       state: z.enum(['open', 'closed', 'all']).describe('Filter by issue state').default('open'),
       labels: z.string().describe('Comma-separated label names to filter by (optional)').optional(),
       limit: z.number().describe('Maximum number of issues to return').default(10),
-    }),
+    })),
     execute: async ({ owner, repo, state, labels, limit }) => {
       try {
         const params = new URLSearchParams();

--- a/src/capabilities/github/review-pr.ts
+++ b/src/capabilities/github/review-pr.ts
@@ -1,16 +1,16 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { githubRequest } from '../../utils/github.js';
 
 export function createReviewPrTool() {
   return tool({
     description: 'Get details of a pull request including the diff. Reviews the PR and returns the title, body, changed files, and diff. Optionally post a review comment.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       owner: z.string().describe('Repository owner (username or org)'),
       repo: z.string().describe('Repository name'),
       number: z.number().describe('PR number'),
       comment: z.string().describe('Review comment to post on the PR (optional)').optional(),
-    }),
+    })),
     execute: async ({ owner, repo, number, comment }) => {
       try {
         const pr = await githubRequest(`/repos/${owner}/${repo}/pulls/${number}`);

--- a/src/capabilities/messaging/send-message.ts
+++ b/src/capabilities/messaging/send-message.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 
 export function createSendMessageTool(
@@ -7,9 +7,9 @@ export function createSendMessageTool(
   return tool({
     description:
       'Send a message through the configured outbound channel. For Telegram this sends to the approved Telegram recipients. Use this only when the user explicitly asks you to send something to Telegram or asks for scheduled results to be sent there.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       content: z.string().describe('The message content to send to the approved Telegram recipients'),
-    }),
+    })),
     execute: async ({ content }) => {
       const trimmed = content.trim();
       if (!trimmed) {

--- a/src/capabilities/scheduler/cancel-task.ts
+++ b/src/capabilities/scheduler/cancel-task.ts
@@ -1,13 +1,13 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import type { Scheduler } from '../../core/scheduler.js';
 
 export function createCancelTaskTool(scheduler: Scheduler) {
   return tool({
     description: 'Cancel and remove a scheduled task by its ID.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       id: z.string().describe('ID of the scheduled task to cancel'),
-    }),
+    })),
     execute: async ({ id }) => {
       const manifests = scheduler.getManifests();
       const exists = manifests.some(m => m.id === id);

--- a/src/capabilities/scheduler/list-tasks.ts
+++ b/src/capabilities/scheduler/list-tasks.ts
@@ -1,11 +1,11 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import type { Scheduler, ScheduledTaskManifest } from '../../core/scheduler.js';
 
 export function createListTasksTool(scheduler: Scheduler) {
   return tool({
     description: 'List all scheduled tasks with their cron expressions and descriptions.',
-    parameters: z.object({}),
+    inputSchema: zodSchema(z.object({})),
     execute: async () => {
       const manifests = scheduler.getManifests();
       if (manifests.length === 0) {

--- a/src/capabilities/scheduler/schedule-task.ts
+++ b/src/capabilities/scheduler/schedule-task.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import cron from 'node-cron';
 import type { Scheduler, ScheduledTaskManifest } from '../../core/scheduler.js';
@@ -6,13 +6,13 @@ import type { Scheduler, ScheduledTaskManifest } from '../../core/scheduler.js';
 export function createScheduleTaskTool(scheduler: Scheduler, getContext: () => { channelId: string; channelType: string }) {
   return tool({
     description: 'Schedule a task. Use "cron" for recurring tasks (e.g. "0 9 * * *" for daily at 9am) or "delay_seconds" for one-shot delayed tasks (e.g. 15 for "remind me in 15 seconds"). Provide exactly one of cron or delay_seconds.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       cron: z.string().optional().describe('Cron expression for recurring tasks (e.g. "0 9 * * *" for daily at 9am)'),
       delay_seconds: z.number().optional().describe('Delay in seconds for one-shot tasks (e.g. 15 for "remind me in 15 seconds")'),
       description: z.string().describe('Human-readable description of what this task does'),
       prompt: z.string().optional().describe('Prompt to send to the agent when the task fires'),
       skill_name: z.string().optional().describe('Name of a skill to invoke when the task fires'),
-    }),
+    })),
     execute: async ({ cron: cronExpr, delay_seconds, description, prompt, skill_name }) => {
       if (!cronExpr && !delay_seconds) {
         return 'Either cron or delay_seconds must be provided.';

--- a/src/capabilities/shell/approve-command.ts
+++ b/src/capabilities/shell/approve-command.ts
@@ -1,13 +1,13 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import type { PermissionManager } from '../permissions.js';
 
 export function createApproveCommandTool(permissions: PermissionManager) {
   return tool({
     description: 'Permanently approve a command type so it runs without asking in the future. Use this when the user says "always" or "always approve" for a command. For example, if the user says "always approve curl", call this with command="curl".',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       command: z.string().describe('The base command to permanently approve (e.g. "curl", "docker", "npm")'),
-    }),
+    })),
     execute: async ({ command }) => {
       const baseCmd = command.trim().split(/\s+/)[0];
       permissions.addApprovedCommand(baseCmd);

--- a/src/capabilities/shell/cd.ts
+++ b/src/capabilities/shell/cd.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { resolve, isAbsolute } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
@@ -6,9 +6,9 @@ import { existsSync, statSync } from 'node:fs';
 export function createCdTool(getCwd: () => string, setCwd: (dir: string) => void) {
   return tool({
     description: 'Change the current working directory. All subsequent file operations, shell commands, and git operations will use this directory. Use this before running commands in a specific project folder.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       path: z.string().describe('The directory to change to. Can be absolute or relative to the current directory.'),
-    }),
+    })),
     execute: async ({ path }) => {
       const cwd = getCwd();
       const resolved = isAbsolute(path) ? resolve(path) : resolve(cwd, path);

--- a/src/capabilities/shell/run-command.ts
+++ b/src/capabilities/shell/run-command.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 import { resolve, isAbsolute } from 'node:path';
@@ -13,9 +13,9 @@ export function createRunCommandTool(permissions: PermissionManager, getCwd: () 
 Blocked commands (sudo, rm -rf /, etc.) are never executed.
 Auto-approved commands (ls, cat, git status, curl, etc.) run without asking.
 Other commands require user approval.`,
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       command: z.string().describe('The shell command to execute'),
-    }),
+    })),
     execute: async ({ command }) => {
       const check = await permissions.checkShellCommand(command);
       if (!check.allowed) {

--- a/src/capabilities/skills/install-skill.ts
+++ b/src/capabilities/skills/install-skill.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import type { SkillLoader } from '../../skills/loader.js';
 import { parse as parseYaml } from 'yaml';
@@ -6,10 +6,10 @@ import { parse as parseYaml } from 'yaml';
 export function createInstallSkillTool(skillLoader: SkillLoader) {
   return tool({
     description: 'Install a new skill by providing SKILL.md markdown content or a URL. The content must have YAML frontmatter (---) with at least name and description fields.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       content: z.string().optional().describe('Raw SKILL.md markdown content with YAML frontmatter'),
       url: z.string().optional().describe('URL to fetch a SKILL.md from'),
-    }),
+    })),
     execute: async ({ content, url }) => {
       let skillContent: string;
 

--- a/src/capabilities/skills/list-skills.ts
+++ b/src/capabilities/skills/list-skills.ts
@@ -1,11 +1,11 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import type { SkillLoader } from '../../skills/loader.js';
 
 export function createListSkillsTool(skillLoader: SkillLoader) {
   return tool({
     description: 'List all installed skills with their names and descriptions.',
-    parameters: z.object({}),
+    inputSchema: zodSchema(z.object({})),
     execute: async () => {
       const skills = skillLoader.getDiscovered();
       if (skills.length === 0) {

--- a/src/capabilities/skills/use-skill.ts
+++ b/src/capabilities/skills/use-skill.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import type { SkillLoader } from '../../skills/loader.js';
 import type { PermissionManager } from '../permissions.js';
@@ -6,9 +6,9 @@ import type { PermissionManager } from '../permissions.js';
 export function createUseSkillTool(skillLoader: SkillLoader, permissions: PermissionManager) {
   return tool({
     description: 'Load and invoke a skill by name. Returns the skill\'s full instructions which should be followed as guidance for the current task.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       name: z.string().describe('Name of the skill to invoke'),
-    }),
+    })),
     execute: async ({ name }) => {
       const skill = skillLoader.load(name);
       if (!skill) {

--- a/src/capabilities/system/budget-status.ts
+++ b/src/capabilities/system/budget-status.ts
@@ -1,11 +1,11 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 import type { TokenBudget } from '../../utils/tokens.js';
 
 export function createBudgetStatusTool(tokenBudget: TokenBudget) {
   return tool({
     description: 'Check the current token budget status — how many tokens have been used today, how many remain, and what percentage is consumed.',
-    parameters: z.object({}),
+    inputSchema: zodSchema(z.object({})),
     execute: async () => {
       return tokenBudget.getStatusText();
     },

--- a/src/capabilities/web/fetch-url.ts
+++ b/src/capabilities/web/fetch-url.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, zodSchema } from 'ai';
 import { z } from 'zod';
 
 const MAX_CONTENT_LENGTH = 15000;
@@ -44,10 +44,10 @@ function stripHtml(html: string): string {
 export function createFetchUrlTool() {
   return tool({
     description: 'Fetch a URL and return its content as text. Strips HTML to readable markdown-like format. Useful for reading documentation, APIs, or web pages.',
-    parameters: z.object({
+    inputSchema: zodSchema(z.object({
       url: z.string().describe('The URL to fetch'),
       format: z.enum(['text', 'markdown']).optional().describe('Output format (default: markdown)'),
-    }),
+    })),
     execute: async ({ url, format }) => {
       const outputFormat = format ?? 'markdown';
 

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -1,4 +1,4 @@
-import { generateText, streamText } from 'ai';
+import { generateText, streamText, stepCountIs } from 'ai';
 import type { ChannelMessage, ChannelType } from '../types/channel.js';
 import type { ProviderRegistry } from '../providers/registry.js';
 import type { Identity } from '../soul/identity.js';
@@ -9,6 +9,7 @@ import type { MercuryConfig } from '../utils/config.js';
 import type { TokenBudget } from '../utils/tokens.js';
 import type { CapabilityRegistry } from '../capabilities/registry.js';
 import type { ScheduledTaskManifest } from './scheduler.js';
+import { DeepSeekProvider } from '../providers/deepseek.js';
 import { Lifecycle } from './lifecycle.js';
 import { Scheduler } from './scheduler.js';
 import { logger } from '../utils/logger.js';
@@ -515,6 +516,10 @@ export class Agent {
 
       for (const provider of fallbackIterator) {
         try {
+          const deepseekProviderOptions = provider instanceof DeepSeekProvider && provider.isReasoner
+            ? { deepseek: { thinking: { type: 'enabled' as const } } }
+            : undefined;
+
           logger.info({ provider: provider.name, model: provider.getModel(), steps: MAX_STEPS, stream: canStream }, 'Generating agentic response');
 
           if (canStream && channel) {
@@ -523,8 +528,9 @@ export class Agent {
               system: systemPrompt,
               messages,
               tools: this.capabilities.getTools(),
-              maxSteps: MAX_STEPS,
+              stopWhen: stepCountIs(MAX_STEPS),
               abortSignal: loopAbortController.signal,
+              ...(deepseekProviderOptions ? { providerOptions: deepseekProviderOptions } : {}),
               onStepFinish: async ({ toolCalls, toolResults }) => {
                 if (toolCalls && toolResults && toolCalls.length > 0) {
                   const names = toolCalls.map((tc: any) => tc.toolName).join(', ');
@@ -540,7 +546,7 @@ export class Agent {
                       resultStr.includes('Command failed') ||
                       resultStr.startsWith('Command exited with code')
                     );
-                    loopDetector.record(tc.toolName, tc.args as Record<string, any>, failed);
+                    loopDetector.record(tc.toolName, tc.input as Record<string, any>, failed);
                   }
                   if (loopDetector.detectAbsoluteLimit()) {
                     logger.warn('Absolute tool call limit reached — aborting');
@@ -595,7 +601,7 @@ export class Agent {
                   if (channel && msg.channelType !== 'internal') {
                     if (channel instanceof CLIChannel) {
                       for (const tc of toolCalls) {
-                        await (channel as CLIChannel).sendToolFeedback(tc.toolName, tc.args as Record<string, any>).catch(() => {});
+                        await (channel as CLIChannel).sendToolFeedback(tc.toolName, tc.input as Record<string, any>).catch(() => {});
                       }
                       if (toolResults) {
                         for (let i = 0; i < toolResults.length; i++) {
@@ -609,7 +615,7 @@ export class Agent {
                     } else if (channel instanceof TelegramChannel) {
                       const tgCh = channel as TelegramChannel;
                       for (const tc of toolCalls) {
-                        await tgCh.sendToolFeedback(tc.toolName, tc.args as Record<string, any>, msg.channelId).catch(() => {});
+                        await tgCh.sendToolFeedback(tc.toolName, tc.input as Record<string, any>, msg.channelId).catch(() => {});
                       }
                       if (toolResults) {
                         for (let i = 0; i < toolResults.length; i++) {
@@ -676,7 +682,9 @@ export class Agent {
               streamResult.usage,
             ]);
 
-            result = { text: fullText, usage };
+            const streamReasoning = await streamResult.reasoning;
+
+            result = { text: fullText, usage, reasoning: streamReasoning };
             streamedText = fullText;
             loopDetector.recordStepText(fullText);
           } else {
@@ -685,8 +693,9 @@ export class Agent {
               system: systemPrompt,
               messages,
               tools: this.capabilities.getTools(),
-              maxSteps: MAX_STEPS,
+              stopWhen: stepCountIs(MAX_STEPS),
               abortSignal: loopAbortController.signal,
+              ...(deepseekProviderOptions ? { providerOptions: deepseekProviderOptions } : {}),
               onStepFinish: async ({ toolCalls, toolResults }) => {
                 if (toolCalls && toolResults && toolCalls.length > 0) {
                   const names = toolCalls.map((tc: any) => tc.toolName).join(', ');
@@ -702,7 +711,7 @@ export class Agent {
                       resultStr.includes('Command failed') ||
                       resultStr.startsWith('Command exited with code')
                     );
-                    loopDetector.record(tc.toolName, tc.args as Record<string, any>, failed);
+                    loopDetector.record(tc.toolName, tc.input as Record<string, any>, failed);
                   }
                   if (loopDetector.detectAbsoluteLimit()) {
                     logger.warn('Absolute tool call limit reached — aborting');
@@ -757,7 +766,7 @@ export class Agent {
                   if (channel && msg.channelType !== 'internal') {
                     if (channel instanceof CLIChannel) {
                       for (const tc of toolCalls) {
-                        await (channel as CLIChannel).sendToolFeedback(tc.toolName, tc.args as Record<string, any>).catch(() => {});
+                        await (channel as CLIChannel).sendToolFeedback(tc.toolName, tc.input as Record<string, any>).catch(() => {});
                       }
                       if (toolResults) {
                         for (let i = 0; i < toolResults.length; i++) {
@@ -771,7 +780,7 @@ export class Agent {
                     } else if (channel instanceof TelegramChannel) {
                       const tgCh = channel as TelegramChannel;
                       for (const tc of toolCalls) {
-                        await tgCh.sendToolFeedback(tc.toolName, tc.args as Record<string, any>, msg.channelId).catch(() => {});
+                        await tgCh.sendToolFeedback(tc.toolName, tc.input as Record<string, any>, msg.channelId).catch(() => {});
                       }
                       if (toolResults) {
                         for (let i = 0; i < toolResults.length; i++) {
@@ -855,9 +864,9 @@ export class Agent {
       this.tokenBudget.recordUsage({
         provider: usedProvider!.name,
         model: usedProvider!.model,
-        inputTokens: result.usage?.promptTokens ?? 0,
-        outputTokens: result.usage?.completionTokens ?? 0,
-        totalTokens: (result.usage?.promptTokens ?? 0) + (result.usage?.completionTokens ?? 0),
+        inputTokens: result.usage?.inputTokens ?? 0,
+        outputTokens: result.usage?.outputTokens ?? 0,
+        totalTokens: (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0),
         channelType: msg.channelType,
       });
 
@@ -873,7 +882,8 @@ export class Agent {
         timestamp: Date.now(),
         role: 'assistant',
         content: finalText,
-        tokenCount: (result.usage?.promptTokens ?? 0) + (result.usage?.completionTokens ?? 0),
+        tokenCount: (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0),
+        reasoning: result.reasoning || undefined,
       });
 
       this.episodic.record({
@@ -1084,15 +1094,15 @@ Always specify owner and repo parameters on GitHub tools. The user's GitHub user
         messages: [
           { role: 'user', content: `User: ${userMessage}\nAssistant: ${agentResponse}` },
         ],
-        maxTokens: 400,
+        maxOutputTokens: 400,
       });
 
       this.tokenBudget.recordUsage({
         provider: provider.name,
         model: provider.getModel(),
-        inputTokens: result.usage?.promptTokens ?? 0,
-        outputTokens: result.usage?.completionTokens ?? 0,
-        totalTokens: (result.usage?.promptTokens ?? 0) + (result.usage?.completionTokens ?? 0),
+        inputTokens: result.usage?.inputTokens ?? 0,
+        outputTokens: result.usage?.outputTokens ?? 0,
+        totalTokens: (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0),
         channelType: 'internal',
       });
 
@@ -1206,6 +1216,12 @@ Always specify owner and repo parameters on GitHub tools. The user's GitHub user
 
     if (cmd === '/help') {
       await channel.send(ctx.manual(), channelId);
+      return true;
+    }
+
+    if (cmd === '/exit' || cmd === '/quit') {
+      await channel.send('Goodbye! Shutting down Mercury...', channelId);
+      this.shutdown();
       return true;
     }
 

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -32,6 +32,7 @@ export interface MemoryEntry {
   role: 'user' | 'assistant' | 'system';
   content: string;
   tokenCount?: number;
+  reasoning?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -29,9 +29,9 @@ export class AnthropicProvider extends BaseProvider {
 
     return {
       text: result.text,
-      inputTokens: result.usage?.promptTokens ?? 0,
-      outputTokens: result.usage?.completionTokens ?? 0,
-      totalTokens: (result.usage?.promptTokens ?? 0) + (result.usage?.completionTokens ?? 0),
+      inputTokens: result.usage?.inputTokens ?? 0,
+      outputTokens: result.usage?.outputTokens ?? 0,
+      totalTokens: (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0),
       model: this.model,
       provider: this.name,
     };
@@ -54,7 +54,7 @@ export class AnthropicProvider extends BaseProvider {
     return this.config.apiKey.length > 0;
   }
 
-  getModelInstance() {
+  getModelInstance(): any {
     return this.modelInstance;
   }
 }

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -1,0 +1,39 @@
+import { createDeepSeek } from '@ai-sdk/deepseek';
+import { BaseProvider } from './base.js';
+import type { ProviderConfig } from '../utils/config.js';
+
+export class DeepSeekProvider extends BaseProvider {
+  readonly name: string;
+  readonly model: string;
+  private modelInstance: any;
+  readonly isReasoner: boolean;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    this.name = config.name;
+    this.model = config.model;
+    this.isReasoner = config.model === 'deepseek-reasoner';
+
+    const client = createDeepSeek({
+      apiKey: config.apiKey,
+      baseURL: config.baseUrl,
+    });
+    this.modelInstance = client(config.model);
+  }
+
+  async generateText(_prompt: string, _systemPrompt: string): Promise<never> {
+    throw new Error('Use getModelInstance() with the AI SDK agent loop');
+  }
+
+  async *streamText(_prompt: string, _systemPrompt: string): AsyncIterable<never> {
+    throw new Error('Use getModelInstance() with the AI SDK agent loop');
+  }
+
+  isAvailable(): boolean {
+    return this.config.apiKey.length > 0;
+  }
+
+  getModelInstance() {
+    return this.modelInstance;
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 export { BaseProvider } from './base.js';
 export { OpenAICompatProvider } from './openai-compat.js';
 export { AnthropicProvider } from './anthropic.js';
+export { DeepSeekProvider } from './deepseek.js';
 export { OllamaProvider } from './ollama.js';
 export { ProviderRegistry } from './registry.js';
 export type { LLMResponse, LLMStreamChunk } from './base.js';

--- a/src/providers/openai-compat.ts
+++ b/src/providers/openai-compat.ts
@@ -32,9 +32,9 @@ export class OpenAICompatProvider extends BaseProvider {
 
     return {
       text: result.text,
-      inputTokens: result.usage?.promptTokens ?? 0,
-      outputTokens: result.usage?.completionTokens ?? 0,
-      totalTokens: (result.usage?.promptTokens ?? 0) + (result.usage?.completionTokens ?? 0),
+      inputTokens: result.usage?.inputTokens ?? 0,
+      outputTokens: result.usage?.outputTokens ?? 0,
+      totalTokens: (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0),
       model: this.model,
       provider: this.name,
     };
@@ -57,7 +57,7 @@ export class OpenAICompatProvider extends BaseProvider {
     return this.config.apiKey.length > 0;
   }
 
-  getModelInstance() {
+  getModelInstance(): any {
     return this.modelInstance;
   }
 }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -3,6 +3,7 @@ import { isProviderConfigured } from '../utils/config.js';
 import type { BaseProvider } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { AnthropicProvider } from './anthropic.js';
+import { DeepSeekProvider } from './deepseek.js';
 import { OllamaProvider } from './ollama.js';
 import { logger } from '../utils/logger.js';
 
@@ -29,6 +30,8 @@ export class ProviderRegistry {
         let provider: BaseProvider;
         if (pc.name === 'anthropic') {
           provider = new AnthropicProvider(pc);
+        } else if (pc.name === 'deepseek') {
+          provider = new DeepSeekProvider(pc);
         } else if (pc.name === 'ollamaCloud' || pc.name === 'ollamaLocal') {
           provider = new OllamaProvider(pc);
         } else {


### PR DESCRIPTION
…it command

- Add DeepSeekProvider using @ai-sdk/deepseek with reasoning mode support
- Upgrade ai (v4→v6), @ai-sdk/anthropic (v1→v3), @ai-sdk/openai (v1→v3)
- Migrate tool definitions: parameters → inputSchema/zodSchema
- Migrate agent loop: maxSteps → stepCountIs, tc.args → tc.input, promptTokens/completionTokens → inputTokens/outputTokens, maxTokens → maxOutputTokens
- Add DeepSeek providerOptions for thinking mode (deepseek-reasoner)
- Capture reasoning from stream results
- Add reasoning field to MemoryEntry
- Update DEEPSEEK_MODEL default to deepseek-v4-flash
- Add /exit and /quit CLI commands to gracefully shut down