### PR TITLE
feat: add Xiaomi MiMo provider support (pay-as-you-go & token plan)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,18 @@ OLLAMA_LOCAL_BASE_URL=http://127.0.0.1:11434/api
 OLLAMA_LOCAL_MODEL=gpt-oss:20b
 OLLAMA_LOCAL_ENABLED=false
 
-# Default provider: deepseek | openai | anthropic | grok | ollamaCloud | ollamaLocal
+# MiMo / Xiaomi (OpenAI-compatible API)
+MIMO_API_KEY=
+MIMO_BASE_URL=https://api.xiaomimimo.com/v1
+MIMO_MODEL=mimo-v2.5-pro
+
+# MiMo Token Plan / Xiaomi (subscription-based)
+MIMO_TOKEN_PLAN_API_KEY=
+MIMO_TOKEN_PLAN_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
+MIMO_TOKEN_PLAN_MODEL=mimo-v2.5-pro
+MIMO_TOKEN_PLAN_ENABLED=false
+
+# Default provider: deepseek | openai | anthropic | grok | ollamaCloud | ollamaLocal | mimo | mimoTokenPlan
 DEFAULT_PROVIDER=deepseek
 
 # ── Telegram ──

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,8 @@ const PROVIDER_OPTIONS: Array<{ key: ProviderName; label: string }> = [
   { key: 'grok', label: 'Grok (xAI)' },
   { key: 'ollamaCloud', label: 'Ollama Cloud' },
   { key: 'ollamaLocal', label: 'Ollama Local' },
+  { key: 'mimo', label: 'MiMo (Xiaomi)' },
+  { key: 'mimoTokenPlan', label: 'MiMo Token Plan (Xiaomi)' },
 ];
 
 function getConfiguredProviderNames(config: MercuryConfig): ProviderName[] {
@@ -245,6 +247,18 @@ function validateApiKey(provider: ProviderName, value: string): string | null {
     return looksLikeToken(value)
       ? null
       : 'Ollama Cloud keys must look like a real API token: long, no spaces, and not plain text.';
+  }
+
+  if (provider === 'mimo') {
+    return /^sk-[A-Za-z0-9_-]{16,}$/i.test(value)
+      ? null
+      : 'MiMo keys must start with `sk-`.';
+  }
+
+  if (provider === 'mimoTokenPlan') {
+    return /^tp-[A-Za-z0-9_-]{16,}$/i.test(value)
+      ? null
+      : 'MiMo Token Plan keys must start with `tp-`.';
   }
 
   return null;
@@ -665,6 +679,40 @@ async function configure(existingConfig?: MercuryConfig): Promise<void> {
           config.providers.ollamaLocal.baseUrl = result.baseUrl;
           config.providers.ollamaLocal.model = result.model;
           config.providers.ollamaLocal.enabled = true;
+        }
+        continue;
+      }
+
+      if (provider === 'mimo') {
+        const mask = isReconfig && config.providers.mimo.apiKey ? ` [${maskKey(config.providers.mimo.apiKey)}]` : '';
+        const result = await promptApiKeyWithModelSelection(
+          config,
+          'mimo',
+          'MiMo',
+          chalk.white(`  MiMo API key${mask}${isReconfig ? '' : ' (Enter to skip)'}: `),
+          isReconfig,
+        );
+        if (!result.skipped && result.apiKey && result.model) {
+          config.providers.mimo.apiKey = result.apiKey;
+          config.providers.mimo.model = result.model;
+          config.providers.mimo.enabled = true;
+        }
+        continue;
+      }
+
+      if (provider === 'mimoTokenPlan') {
+        const mask = isReconfig && config.providers.mimoTokenPlan.apiKey ? ` [${maskKey(config.providers.mimoTokenPlan.apiKey)}]` : '';
+        const result = await promptApiKeyWithModelSelection(
+          config,
+          'mimoTokenPlan',
+          'MiMo Token Plan',
+          chalk.white(`  MiMo Token Plan API key${mask}${isReconfig ? '' : ' (Enter to skip)'}: `),
+          isReconfig,
+        );
+        if (!result.skipped && result.apiKey && result.model) {
+          config.providers.mimoTokenPlan.apiKey = result.apiKey;
+          config.providers.mimoTokenPlan.model = result.model;
+          config.providers.mimoTokenPlan.enabled = true;
         }
       }
     }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,5 +3,6 @@ export { OpenAICompatProvider } from './openai-compat.js';
 export { AnthropicProvider } from './anthropic.js';
 export { DeepSeekProvider } from './deepseek.js';
 export { OllamaProvider } from './ollama.js';
+export { MiMoProvider } from './mimo.js';
 export { ProviderRegistry } from './registry.js';
 export type { LLMResponse, LLMStreamChunk } from './base.js';

--- a/src/providers/mimo.ts
+++ b/src/providers/mimo.ts
@@ -1,0 +1,37 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { BaseProvider } from './base.js';
+import type { ProviderConfig } from '../utils/config.js';
+
+export class MiMoProvider extends BaseProvider {
+  readonly name: string;
+  readonly model: string;
+  private modelInstance: any;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    this.name = config.name;
+    this.model = config.model;
+
+    const client = createOpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseUrl,
+    });
+    this.modelInstance = client.chat(config.model);
+  }
+
+  async generateText(_prompt: string, _systemPrompt: string): Promise<never> {
+    throw new Error('Use getModelInstance() with the AI SDK agent loop');
+  }
+
+  async *streamText(_prompt: string, _systemPrompt: string): AsyncIterable<never> {
+    throw new Error('Use getModelInstance() with the AI SDK agent loop');
+  }
+
+  isAvailable(): boolean {
+    return this.config.apiKey.length > 0;
+  }
+
+  getModelInstance() {
+    return this.modelInstance;
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -5,6 +5,7 @@ import { OpenAICompatProvider } from './openai-compat.js';
 import { AnthropicProvider } from './anthropic.js';
 import { DeepSeekProvider } from './deepseek.js';
 import { OllamaProvider } from './ollama.js';
+import { MiMoProvider } from './mimo.js';
 import { logger } from '../utils/logger.js';
 
 export class ProviderRegistry {
@@ -22,6 +23,8 @@ export class ProviderRegistry {
       config.providers.grok,
       config.providers.ollamaCloud,
       config.providers.ollamaLocal,
+      config.providers.mimo,
+      config.providers.mimoTokenPlan,
     ];
 
     for (const pc of entries) {
@@ -34,6 +37,8 @@ export class ProviderRegistry {
           provider = new DeepSeekProvider(pc);
         } else if (pc.name === 'ollamaCloud' || pc.name === 'ollamaLocal') {
           provider = new OllamaProvider(pc);
+        } else if (pc.name === 'mimo' || pc.name === 'mimoTokenPlan') {
+          provider = new MiMoProvider(pc);
         } else {
           provider = new OpenAICompatProvider(pc);
         }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -52,7 +52,9 @@ export type ProviderName =
   | 'deepseek'
   | 'grok'
   | 'ollamaCloud'
-  | 'ollamaLocal';
+  | 'ollamaLocal'
+  | 'mimo'
+  | 'mimoTokenPlan';
 
 export interface MercuryConfig {
   identity: {
@@ -68,6 +70,8 @@ export interface MercuryConfig {
     grok: ProviderConfig;
     ollamaCloud: ProviderConfig;
     ollamaLocal: ProviderConfig;
+    mimo: ProviderConfig;
+    mimoTokenPlan: ProviderConfig;
   };
   channels: {
     telegram: {
@@ -172,6 +176,20 @@ export function getDefaultConfig(): MercuryConfig {
         baseUrl: getEnv('OLLAMA_LOCAL_BASE_URL', 'http://127.0.0.1:11434/api'),
         model: getEnv('OLLAMA_LOCAL_MODEL', 'gpt-oss:20b'),
         enabled: getEnvBool('OLLAMA_LOCAL_ENABLED', false),
+      },
+      mimo: {
+        name: 'mimo',
+        apiKey: getEnv('MIMO_API_KEY', ''),
+        baseUrl: getEnv('MIMO_BASE_URL', 'https://api.xiaomimimo.com/v1'),
+        model: getEnv('MIMO_MODEL', 'mimo-v2.5-pro'),
+        enabled: getEnvBool('MIMO_ENABLED', true),
+      },
+      mimoTokenPlan: {
+        name: 'mimoTokenPlan',
+        apiKey: getEnv('MIMO_TOKEN_PLAN_API_KEY', ''),
+        baseUrl: getEnv('MIMO_TOKEN_PLAN_BASE_URL', 'https://token-plan-cn.xiaomimimo.com/v1'),
+        model: getEnv('MIMO_TOKEN_PLAN_MODEL', 'mimo-v2.5-pro'),
+        enabled: getEnvBool('MIMO_TOKEN_PLAN_ENABLED', false),
       },
     },
     channels: {

--- a/src/utils/provider-models.test.ts
+++ b/src/utils/provider-models.test.ts
@@ -42,4 +42,36 @@ describe('buildModelCatalog', () => {
     expect(catalog.models).toHaveLength(7);
     expect(catalog.models).not.toContain('claude-sonnet-4-20250514');
   });
+
+  it('prefers mimo-v2.5-pro for MiMo when available', () => {
+    const catalog = buildModelCatalog('mimo', [
+      'mimo-v2.5-pro',
+      'mimo-v2-flash',
+      'mimo-v2.5',
+    ]);
+
+    expect(catalog.recommendedModel).toBe('mimo-v2.5-pro');
+    expect(catalog.models).toContain('mimo-v2.5');
+    expect(catalog.models).toContain('mimo-v2-flash');
+  });
+
+  it('falls back to the first MiMo model when no preferred default is available', () => {
+    const catalog = buildModelCatalog('mimo', [
+      'mimo-v2-flash',
+    ]);
+
+    expect(catalog.recommendedModel).toBe('mimo-v2-flash');
+  });
+
+  it('prefers mimo-v2.5-pro for MiMo Token Plan when available', () => {
+    const catalog = buildModelCatalog('mimoTokenPlan', [
+      'mimo-v2.5-pro',
+      'mimo-v2-flash',
+      'mimo-v2.5',
+    ]);
+
+    expect(catalog.recommendedModel).toBe('mimo-v2.5-pro');
+    expect(catalog.models).toContain('mimo-v2.5');
+    expect(catalog.models).toContain('mimo-v2-flash');
+  });
 });

--- a/src/utils/provider-models.ts
+++ b/src/utils/provider-models.ts
@@ -51,6 +51,16 @@ const OLLAMA_LOCAL_PREFERRED_MODELS = [
   'gpt-oss:120b',
 ] as const;
 
+const MIMO_PREFERRED_MODELS = [
+  'mimo-v2.5-pro',
+  'mimo-v2.5',
+  'mimo-v2-pro',
+  'mimo-v2-omni',
+  'mimo-v2-flash',
+] as const;
+
+const MIMO_TOKEN_PLAN_PREFERRED_MODELS = MIMO_PREFERRED_MODELS;
+
 export class ProviderModelFetchError extends Error {
   constructor(message: string) {
     super(message);
@@ -154,6 +164,8 @@ function chooseRecommendedModel(
     grok: GROK_PREFERRED_MODELS,
     ollamaCloud: OLLAMA_CLOUD_PREFERRED_MODELS,
     ollamaLocal: OLLAMA_LOCAL_PREFERRED_MODELS,
+    mimo: MIMO_PREFERRED_MODELS,
+    mimoTokenPlan: MIMO_TOKEN_PLAN_PREFERRED_MODELS,
   };
 
   for (const candidate of preferredByProvider[provider]) {
@@ -187,6 +199,8 @@ export function buildModelCatalog(
     grok: GROK_PREFERRED_MODELS,
     ollamaCloud: OLLAMA_CLOUD_PREFERRED_MODELS,
     ollamaLocal: OLLAMA_LOCAL_PREFERRED_MODELS,
+    mimo: MIMO_PREFERRED_MODELS,
+    mimoTokenPlan: MIMO_TOKEN_PLAN_PREFERRED_MODELS,
   };
 
   const withoutRecommended = filtered.filter((model) => model !== recommendedModel);
@@ -281,6 +295,48 @@ async function fetchOllamaModels(provider: ProviderName, config: ProviderConfig)
   return buildModelCatalog(provider, ids, config.model);
 }
 
+async function fetchMiMoModels(config: ProviderConfig): Promise<ProviderModelCatalog> {
+  const data = await fetchJson<OpenAIModelResponse>(
+    `${trimTrailingSlash(config.baseUrl)}/models`,
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+    },
+    'Mercury could not fetch models for this MiMo key. Please re-enter it.',
+  );
+
+  const ids = (data.data ?? [])
+    .map((model) => model.id?.trim() ?? '')
+    .filter((id) => {
+      const lower = id.toLowerCase();
+      return lower.startsWith('mimo-') && !lower.includes('tts');
+    });
+
+  return buildModelCatalog('mimo', ids, config.model);
+}
+
+async function fetchMiMoTokenPlanModels(config: ProviderConfig): Promise<ProviderModelCatalog> {
+  const data = await fetchJson<OpenAIModelResponse>(
+    `${trimTrailingSlash(config.baseUrl)}/models`,
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+    },
+    'Mercury could not fetch models for this MiMo Token Plan key. Please re-enter it.',
+  );
+
+  const ids = (data.data ?? [])
+    .map((model) => model.id?.trim() ?? '')
+    .filter((id) => {
+      const lower = id.toLowerCase();
+      return lower.startsWith('mimo-') && !lower.includes('tts');
+    });
+
+  return buildModelCatalog('mimoTokenPlan', ids, config.model);
+}
+
 export async function fetchProviderModelCatalog(
   provider: ProviderName,
   config: ProviderConfig,
@@ -295,6 +351,14 @@ export async function fetchProviderModelCatalog(
 
   if (provider === 'ollamaCloud' || provider === 'ollamaLocal') {
     return fetchOllamaModels(provider, config);
+  }
+
+  if (provider === 'mimo') {
+    return fetchMiMoModels(config);
+  }
+
+  if (provider === 'mimoTokenPlan') {
+    return fetchMiMoTokenPlanModels(config);
   }
 
   return fetchOpenAICompatModels(provider, config);


### PR DESCRIPTION
## Summary

- Integrate Xiaomi MiMo as a first-class LLM provider with two billing modes
- **MiMo (pay-as-you-go)**: `sk-` key prefix, `https://api.xiaomimimo.com/v1`
- **MiMo Token Plan (subscription)**: `tp-` key prefix, `https://token-plan-cn.xiaomimimo.com/v1`
- MiMo provides an OpenAI-compatible API, integrated via `@ai-sdk/openai`'s `chat()` method to ensure requests hit `/v1/chat/completions` instead of the Responses API
- Full setup wizard integration (provider selection, API key validation, model catalog fetching)

### Files changed

| File | Change |
|---|---|
| `src/providers/mimo.ts` | New `MiMoProvider` class using `@ai-sdk/openai` |
| `src/providers/registry.ts` | Register and route `mimo` / `mimoTokenPlan` providers |
| `src/providers/index.ts` | Export `MiMoProvider` |
| `src/utils/config.ts` | Add `ProviderName` types, `MercuryConfig` entries, default config |
| `src/utils/provider-models.ts` | Add preferred models, `fetchMiMoModels()`, catalog routing |
| `src/index.ts` | Setup wizard: provider option, key validation, config flow |
| `.env.example` | Add MiMo environment variables |
| `src/utils/provider-models.test.ts` | Add 3 MiMo model catalog tests |

### Reference

- MiMo API docs: https://platform.xiaomimimo.com/docs/integration/tools-overview
- MiMo supports OpenAI-compatible `/v1/chat/completions` with tool calling, streaming, and reasoning mode

## Test plan

- [x] `npm test` passes (25 tests, including 3 new MiMo tests)
- [x] Manual test: `mercury start` → select MiMo → enter API key → model selection works
- [x] Manual test: agent loop runs successfully with `mimo-v2.5-pro` model