### PR TITLE
fix: hide CMD window on Windows when spawning shell commands

### DIFF
--- a/src/capabilities/shell/run-command.ts
+++ b/src/capabilities/shell/run-command.ts
@@ -30,6 +30,7 @@ function executeCommand(command: string, cwd: string, timeoutMs: number): Promis
       cwd,
       shell: true,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
 
     const finish = (exitCode: number | null, timedOut: boolean) => {

--- a/src/core/background-tasks.ts
+++ b/src/core/background-tasks.ts
@@ -111,6 +111,7 @@ export class BackgroundTaskManager {
         cwd,
         shell: true,
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
       });
 
       task.pid = child.pid ?? undefined;


### PR DESCRIPTION
## Problem

On Windows, shell commands spawn a visible cmd.exe window that flashes on screen, degrading user experience.

## Fix

Add  to  options in two files:

-  — the main run_command tool
-  — background task execution

This is a Node.js built-in option (v13.3+) that suppresses the console window on Windows. The daemon launcher () already uses this pattern.

## Test Plan

- [ ] On Windows: verify no CMD window flashes when agent runs shell commands
- [ ] On Windows: verify background tasks also stay hidden
- [ ] On macOS/Linux: verify behavior is unchanged (windowsHide is a no-op)