### PR TITLE
docs(readme): lead with operator outcome before soul-driven framing (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@
 </p>
 
 <p align="center">
-  <strong>Soul-driven AI agent with permission-hardened tools, token budgets, and multi-channel access.</strong>
+  <strong>A permission-hardened AI agent for CLI and Telegram that runs 24/7 with explicit tool approvals, token budgets, and persistent scheduling.</strong>
 </p>
 
 <p align="center">
-  Remembers what matters. Asks before it acts. Runs 24/7 from CLI or Telegram. 31 built-in tools, extensible skills, SQLite-backed Second Brain memory.
+  Soul-driven under the hood — personality, taste, and memory defined in markdown files you own, so Mercury stays distinctly yours while it works.
+</p>
+
+<p align="center">
+  Remembers what matters. Asks before it acts. 31 built-in tools, extensible skills, SQLite-backed Second Brain memory.
 </p>
 
 <p align="center">


### PR DESCRIPTION
Closes #2.

Thanks to @nathan-widjaja for the suggestion — the original opener made the `soul-driven` philosophy do the first-buyer explanation. This PR flips the hero so the concrete operator value lands first, and keeps the soul/persona framing right underneath as the differentiator.

## What changed

Docs-only. Only the hero block in `README.md` was touched; badges, structure, and all downstream sections are unchanged.

**Before**
> **Soul-driven AI agent with permission-hardened tools, token budgets, and multi-channel access.**
>
> Remembers what matters. Asks before it acts. Runs 24/7 from CLI or Telegram. 31 built-in tools, extensible skills, SQLite-backed Second Brain memory.

**After**
> **A permission-hardened AI agent for CLI and Telegram that runs 24/7 with explicit tool approvals, token budgets, and persistent scheduling.**
>
> Soul-driven under the hood — personality, taste, and memory defined in markdown files you own, so Mercury stays distinctly yours while it works.
>
> Remembers what matters. Asks before it acts. 31 built-in tools, extensible skills, SQLite-backed Second Brain memory.

## Why

- Leads with the switch reason an operator actually evaluates: permission-hardened, 24/7, CLI + Telegram, explicit tool approvals, token budgets, persistent scheduling.
- Keeps the soul/persona angle as the second paragraph so it still differentiates the product — it just no longer has to carry the first-buyer explanation alone.
- The `Why Mercury?` section and the `Soul-driven` bullet further down are untouched, so the full philosophy framing is preserved in context.

## Scope

- docs-only change (`README.md` hero text)
- No code, config, or translated README (`README.zh-CN.md`) changes in this PR — happy to follow up on the zh-CN version in a separate PR if maintainers want matching copy.

Closes #2.