### PR TITLE
feat: add Astraflow provider support (global + CN endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,18 @@ MIMO_TOKEN_PLAN_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
 MIMO_TOKEN_PLAN_MODEL=mimo-v2.5-pro
 MIMO_TOKEN_PLAN_ENABLED=false
 
-# Default provider: deepseek | openai | anthropic | grok | ollamaCloud | ollamaLocal | openaiCompat | mimo | mimoTokenPlan
+# Astraflow / UCloud 优刻得 (OpenAI-compatible, 200+ models — https://www.ucloud.cn/site/product/modelverse.html)
+ASTRAFLOW_API_KEY=
+ASTRAFLOW_BASE_URL=https://api-us-ca.umodelverse.ai/v1
+ASTRAFLOW_MODEL=deepseek-v3
+
+# Astraflow CN / UCloud 优刻得 China endpoint
+ASTRAFLOW_CN_API_KEY=
+ASTRAFLOW_CN_BASE_URL=https://api.modelverse.cn/v1
+ASTRAFLOW_CN_MODEL=deepseek-v3
+ASTRAFLOW_CN_ENABLED=false
+
+# Default provider: deepseek | openai | anthropic | grok | ollamaCloud | ollamaLocal | openaiCompat | mimo | mimoTokenPlan | astraflow | astraflowCn
 DEFAULT_PROVIDER=deepseek
 
 # ── Telegram ──

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -19,6 +19,9 @@ async function createProvider(pc: ProviderConfig): Promise<BaseProvider> {
   } else if (pc.name === 'mimo' || pc.name === 'mimoTokenPlan') {
     const { MiMoProvider } = await import('./mimo.js');
     return new MiMoProvider(pc);
+  } else if (pc.name === 'astraflow' || pc.name === 'astraflowCn') {
+    const { OpenAICompatProvider } = await import('./openai-compat.js');
+    return new OpenAICompatProvider(pc, { useChatApi: true });
   } else if (pc.name === 'chatgptWeb') {
     const { ChatGPTWebProvider } = await import('./chatgpt-web.js');
     return new ChatGPTWebProvider(pc);
@@ -53,6 +56,8 @@ export class ProviderRegistry {
       config.providers.openaiCompat,
       config.providers.mimo,
       config.providers.mimoTokenPlan,
+      config.providers.astraflow,
+      config.providers.astraflowCn,
       config.providers.chatgptWeb,
       config.providers.githubCopilot,
     ];

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -56,6 +56,8 @@ export type ProviderName =
   | 'openaiCompat'
   | 'mimo'
   | 'mimoTokenPlan'
+  | 'astraflow'
+  | 'astraflowCn'
   | 'chatgptWeb'
   | 'githubCopilot';
 
@@ -76,6 +78,8 @@ export interface MercuryConfig {
     openaiCompat: ProviderConfig;
     mimo: ProviderConfig;
     mimoTokenPlan: ProviderConfig;
+    astraflow: ProviderConfig;
+    astraflowCn: ProviderConfig;
     chatgptWeb: ProviderConfig;
     githubCopilot: ProviderConfig;
   };
@@ -222,6 +226,20 @@ export function getDefaultConfig(): MercuryConfig {
         baseUrl: getEnv('MIMO_TOKEN_PLAN_BASE_URL', 'https://token-plan-cn.xiaomimimo.com/v1'),
         model: getEnv('MIMO_TOKEN_PLAN_MODEL', 'mimo-v2.5-pro'),
         enabled: getEnvBool('MIMO_TOKEN_PLAN_ENABLED', false),
+      },
+      astraflow: {
+        name: 'astraflow',
+        apiKey: getEnv('ASTRAFLOW_API_KEY', ''),
+        baseUrl: getEnv('ASTRAFLOW_BASE_URL', 'https://api-us-ca.umodelverse.ai/v1'),
+        model: getEnv('ASTRAFLOW_MODEL', 'deepseek-v3'),
+        enabled: getEnvBool('ASTRAFLOW_ENABLED', true),
+      },
+      astraflowCn: {
+        name: 'astraflowCn',
+        apiKey: getEnv('ASTRAFLOW_CN_API_KEY', ''),
+        baseUrl: getEnv('ASTRAFLOW_CN_BASE_URL', 'https://api.modelverse.cn/v1'),
+        model: getEnv('ASTRAFLOW_CN_MODEL', 'deepseek-v3'),
+        enabled: getEnvBool('ASTRAFLOW_CN_ENABLED', false),
       },
       chatgptWeb: {
         name: 'chatgptWeb',


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://www.ucloud.cn/site/product/modelverse.html) by UCloud (优刻得) as a supported LLM provider. Astraflow is an OpenAI-compatible model aggregation platform supporting 200+ models.

Two endpoints are registered, following the same dual-variant pattern as MiMo:

| Provider name | Env var | Base URL |
|---|---|---|
| `astraflow` | `ASTRAFLOW_API_KEY` | `https://api-us-ca.umodelverse.ai/v1` |
| `astraflowCn` | `ASTRAFLOW_CN_API_KEY` | `https://api.modelverse.cn/v1` |

## Changes

- **`src/utils/config.ts`** — added `astraflow` and `astraflowCn` to `ProviderName` union, `MercuryConfig.providers` interface, and `getDefaultConfig()`
- **`src/providers/registry.ts`** — added both providers to the `entries` array (routed through `OpenAICompatProvider` with `useChatApi: true`, same as `ollamaCloud`)
- **`.env.example`** — documented both env vars and their defaults

## No new files

Because Astraflow is OpenAI-compatible, no new provider class is needed — it reuses the existing `OpenAICompatProvider`, exactly like `grok` and `ollamaCloud`.