### PR TITLE
fix: replace hardcoded zsh shell with dynamic shell detection

### DIFF
--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,0 +1,22 @@
+import {accessSync, constants} from "node:fs";
+
+export function isExecutable(path: string): boolean {
+    try {
+        accessSync(path, constants.X_OK);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Detect the user's preferred shell, falling back zsh → bash → sh. */
+export function detectShell(): string {
+    const envShell = process.env.SHELL;
+    if (envShell && isExecutable(envShell)) return envShell;
+
+    const candidates = ['/bin/zsh', '/bin/bash', '/bin/sh'];
+    for (const shell of candidates) {
+        if (isExecutable(shell)) return shell;
+    }
+    return '/bin/sh';
+}

--- a/src/web/api/workspace-ide.ts
+++ b/src/web/api/workspace-ide.ts
@@ -3,6 +3,7 @@ import { execSync, spawn } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
 import { join, resolve, relative, extname, basename } from 'node:path';
 import { getMercuryHome, loadConfig } from '../../utils/config.js';
+import { detectShell } from '../../utils/shell.js';
 import { generateText } from 'ai';
 import type { ProviderRegistry } from '../../providers/registry.js';
 
@@ -280,7 +281,7 @@ ide.post('/api/terminal/exec', async (c) => {
       encoding: 'utf8',
       timeout: 30000,
       maxBuffer: 2 * 1024 * 1024,
-      shell: '/bin/zsh',
+      shell: detectShell(),
       env: { ...process.env, TERM: 'xterm-256color' },
     });
 


### PR DESCRIPTION
Add detectShell() utility to probe SHELL env var and fall back through zsh → bash → sh, replacing the hardcoded /bin/zsh in terminal exec.

Steps to reproduce: Open the web dashboard, click Workspace, click Terminal. If you don't have zsh installed and are using bash or another shell instead, it will inevitably throw an error.

Additionally, I fixed this bug using Mercury to locate, propose a solution, and apply the fix on its own.