### PR TITLE
Fix ChatGPT Web tool calls and web permission approvals

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -19,6 +19,7 @@ import { BackgroundTaskManager } from './background-tasks.js';
 import { SkillBatcher } from '../skills/batcher.js';
 import type { SkillLoader } from '../skills/loader.js';
 import { logger } from '../utils/logger.js';
+import { ChatGPTWebProvider } from '../providers/chatgpt-web.js';
 import { CLIChannel } from '../channels/cli.js';
 import { TelegramChannel } from '../channels/telegram.js';
 import { formatToolStep, formatNarrative, type NarrativeStep } from '../utils/tool-label.js';
@@ -1126,9 +1127,12 @@ export class Agent {
       for (const provider of fallbackIterator) {
         try {
           this.markProgress(`Calling ${provider.name}...`);
-          const deepseekProviderOptions = provider instanceof DeepSeekProvider && provider.isReasoner
-            ? { deepseek: { thinking: { type: 'enabled' as const } } }
-            : undefined;
+          let providerOptions: Record<string, any> | undefined;
+          if (provider instanceof DeepSeekProvider && provider.isReasoner) {
+            providerOptions = { deepseek: { thinking: { type: 'enabled' as const } } };
+          } else if (provider instanceof ChatGPTWebProvider) {
+            providerOptions = { openai: { store: false } };
+          }
 
           logger.info({ provider: provider.name, model: provider.getModel(), steps: MAX_STEPS, stream: canStream }, 'Generating agentic response');
 
@@ -1141,7 +1145,7 @@ export class Agent {
               maxOutputTokens: MAX_RESPONSE_TOKENS,
               stopWhen: stepCountIs(MAX_STEPS),
               abortSignal: loopAbortController.signal,
-              ...(deepseekProviderOptions ? { providerOptions: deepseekProviderOptions } : {}),
+              ...(providerOptions ? { providerOptions } : {}),
               onStepFinish: async ({ toolCalls, toolResults }) => {
                 this.completedStepCount++;
                 if (toolCalls && toolCalls.length > 0) {
@@ -1384,7 +1388,7 @@ export class Agent {
               maxOutputTokens: MAX_RESPONSE_TOKENS,
               stopWhen: stepCountIs(MAX_STEPS),
               abortSignal: loopAbortController.signal,
-              ...(deepseekProviderOptions ? { providerOptions: deepseekProviderOptions } : {}),
+              ...(providerOptions ? { providerOptions } : {}),
               onStepFinish: async ({ toolCalls, toolResults }) => {
                 this.completedStepCount++;
                 if (toolCalls && toolCalls.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ import { runWithWatchdog } from './cli/watchdog.js';
 import { setGitHubToken } from './utils/github.js';
 import { selectWithArrowKeys } from './utils/arrow-select.js';
 import { ProviderModelFetchError, fetchProviderModelCatalog } from './utils/provider-models.js';
-import { startWebServer, stopWebServer, updateStatus as updateWebStatus, setUserMemory as setWebUserMemory, setWebChannel as setWebWebChannel, setScheduler as setWebScheduler, setAgentSupervisor as setWebSupervisor, setBackgroundTaskManager as setWebBgTasks, setSpotifyClient as setWebSpotify, setProgrammingMode as setWebProgrammingMode, setModelSwitchCallback as setWebModelSwitch, setCurrentProviderCallback as setWebCurrentProvider, setKanbanSupervisor as setWebKanban, setKanbanBoardManager as setWebBoardManager, setKanbanProviders as setWebKanbanProviders, setIDEProviders as setWebIDEProviders } from './web/server.js';
+import { startWebServer, stopWebServer, updateStatus as updateWebStatus, setUserMemory as setWebUserMemory, setWebChannel as setWebWebChannel, setScheduler as setWebScheduler, setPermissionManager as setWebPermissionManager, setAgentSupervisor as setWebSupervisor, setBackgroundTaskManager as setWebBgTasks, setSpotifyClient as setWebSpotify, setProgrammingMode as setWebProgrammingMode, setModelSwitchCallback as setWebModelSwitch, setCurrentProviderCallback as setWebCurrentProvider, setKanbanSupervisor as setWebKanban, setKanbanBoardManager as setWebBoardManager, setKanbanProviders as setWebKanbanProviders, setIDEProviders as setWebIDEProviders } from './web/server.js';
 import { isWebAuthInitialized, setWebPassword } from './web/auth.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -1368,6 +1368,7 @@ async function runAgent(isDaemon: boolean = false): Promise<void> {
   const webChannel = new WebChannel(config.identity.name);
   channels.register('web', webChannel);
   const capabilities = new CapabilityRegistry(skillLoader, scheduler, tokenBudget, undefined, userMemory ?? undefined);
+  setWebPermissionManager(capabilities.permissions);
 
   let supervisor: SubAgentSupervisor | undefined;
   if (config.subagents.enabled) {

--- a/src/providers/chatgpt-web.test.ts
+++ b/src/providers/chatgpt-web.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { sanitiseBody } from './chatgpt-web.js';
+
+describe('sanitiseBody', () => {
+  it('uses non-persistent ChatGPT Codex responses and strips stale item references', () => {
+    const sanitized = JSON.parse(sanitiseBody(JSON.stringify({
+      model: 'gpt-5.5',
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'read the project' }] },
+        { type: 'item_reference', id: 'rs_example' },
+      ],
+      store: undefined,
+      stream: false,
+      max_output_tokens: 4096,
+      temperature: 0,
+      include: ['reasoning.encrypted_content'],
+      instructions: null,
+      tools: [{ type: 'function', name: 'list_files' }],
+    })));
+
+    expect(sanitized.store).toBe(false);
+    expect(sanitized.stream).toBe(true);
+    expect(sanitized.instructions).toBe('You are a helpful assistant.');
+    expect(sanitized.input).not.toContainEqual({ type: 'item_reference', id: 'rs_example' });
+    expect(sanitized.include).toEqual(['reasoning.encrypted_content']);
+    expect(sanitized.tools).toEqual([{ type: 'function', name: 'list_files' }]);
+    expect(sanitized).not.toHaveProperty('max_output_tokens');
+    expect(sanitized).not.toHaveProperty('temperature');
+  });
+});

--- a/src/providers/chatgpt-web.ts
+++ b/src/providers/chatgpt-web.ts
@@ -16,13 +16,18 @@ const UNSUPPORTED_FIELDS = [
 /**
  * Sanitise an outgoing request body for the ChatGPT codex/responses endpoint.
  */
-function sanitiseBody(raw: string): string {
+export function sanitiseBody(raw: string): string {
   const body = JSON.parse(raw);
 
-  // Required
+  // The ChatGPT Codex endpoint rejects persisted responses, so the AI SDK must
+  // inline prior messages/tool results instead of sending item_reference rows.
   body.store = false;
   body.stream = true;
   if (!body.instructions) body.instructions = 'You are a helpful assistant.';
+
+  if (Array.isArray(body.input)) {
+    body.input = body.input.filter((item: any) => item?.type !== 'item_reference');
+  }
 
   // Strip unsupported & undefined/null
   for (const key of UNSUPPORTED_FIELDS) delete body[key];

--- a/src/web/api/system.ts
+++ b/src/web/api/system.ts
@@ -9,9 +9,18 @@ import cron from 'node-cron';
 
 const system = new Hono();
 let scheduler: Scheduler | null = null;
+let permissionManager: PermissionManager | null = null;
 
 export function setScheduler(s: Scheduler | null): void {
   scheduler = s;
+}
+
+export function setPermissionManager(manager: PermissionManager | null): void {
+  permissionManager = manager;
+}
+
+function getPermissionManager(): PermissionManager {
+  return permissionManager ?? new PermissionManager();
 }
 
 system.get('/api/skills', (c) => {
@@ -79,14 +88,14 @@ system.delete('/api/skills/:name', (c) => {
 });
 
 system.get('/api/permissions', (c) => {
-  const manager = new PermissionManager();
+  const manager = getPermissionManager();
   const manifest = manager.getManifest();
   return c.json({ manifest });
 });
 
 system.put('/api/permissions', async (c) => {
   const body = await c.req.json();
-  const manager = new PermissionManager();
+  const manager = getPermissionManager();
   const current = manager.getManifest();
   const next: PermissionsManifest = {
     capabilities: {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -10,7 +10,7 @@ import authRoutes from './api/auth.js';
 import statusRoutes, { updateStatus } from './api/status.js';
 import providerRoutes from './api/providers.js';
 import configRoutes from './api/config.js';
-import systemRoutes, { setScheduler } from './api/system.js';
+import systemRoutes, { setScheduler, setPermissionManager } from './api/system.js';
 import brainRoutes, { setUserMemory } from './api/brain.js';
 import chatRoutes, { setWebChannel, setProgrammingMode, setModelSwitchCallback, setCurrentProviderCallback } from './api/chat.js';
 import agentRoutes, { setAgentSupervisor, setBackgroundTaskManager } from './api/agents.js';
@@ -173,7 +173,7 @@ if (spaAvailable) {
   });
 }
 
-export { updateStatus, setUserMemory, setWebChannel, setScheduler, setAgentSupervisor, setBackgroundTaskManager, setSpotifyClient, setProgrammingMode, setModelSwitchCallback, setCurrentProviderCallback, setKanbanSupervisor, setKanbanBoardManager, setKanbanProviders, setIDEProviders };
+export { updateStatus, setUserMemory, setWebChannel, setScheduler, setPermissionManager, setAgentSupervisor, setBackgroundTaskManager, setSpotifyClient, setProgrammingMode, setModelSwitchCallback, setCurrentProviderCallback, setKanbanSupervisor, setKanbanBoardManager, setKanbanProviders, setIDEProviders };
 
 let webServer: ReturnType<typeof createAdaptorServer> | null = null;
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -197,6 +197,7 @@ process.on('unhandledRejection', (reason: any) => {
 
 export function startWebServer(): { port: number; url: string } {
   const port = getWebPort();
+  const host = process.env.MERCURY_WEB_HOST || '127.0.0.1';
   initWebAuth();
 
   if (spaAvailable) {
@@ -216,11 +217,11 @@ export function startWebServer(): { port: number; url: string } {
     }
   });
 
-  server.listen(port, '127.0.0.1', () => {
-    logger.info(`Web dashboard: http://127.0.0.1:${port}`);
+  server.listen(port, host, () => {
+    logger.info(`Web dashboard: http://${host}:${port}`);
   });
 
-  return { port, url: `http://127.0.0.1:${port}` };
+  return { port, url: `http://${host}:${port}` };
 }
 
 export function stopWebServer(): Promise<void> {

--- a/ui/src/components/chat/PermissionPrompt.tsx
+++ b/ui/src/components/chat/PermissionPrompt.tsx
@@ -48,17 +48,28 @@ export function PermissionPrompt({
 
           {resolved ? (
             <p className="text-xs text-muted-foreground">
-              {resolved === "allow" ? "Allowed" : "Denied"}
+              {resolved === "always"
+                ? "Always allowed and saved"
+                : resolved === "yes"
+                  ? "Allowed for this request"
+                  : "Denied"}
             </p>
           ) : (
-            <div className="flex items-center gap-2">
-              <Button size="sm" onClick={() => handleAction("allow")}>
-                Allow
+            <div className="flex flex-wrap items-center gap-2">
+              <Button size="sm" onClick={() => handleAction("yes")}>
+                Allow Once
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleAction("always")}
+              >
+                Always
               </Button>
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={() => handleAction("deny")}
+                onClick={() => handleAction("no")}
               >
                 Deny
               </Button>

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -110,20 +110,30 @@ function WaitingIndicator() {
 function PermissionPrompt({
   data,
 }: {
-  data: { id: string; tool?: string; description?: string };
+  data: { id: string; tool?: string; description?: string; prompt?: string };
 }) {
   const [resolving, setResolving] = useState(false);
+  const [resolved, setResolved] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   async function handle(action: string) {
     setResolving(true);
+    setError(null);
     try {
-      await api.chat.permission(data.id, action);
+      const res = await api.chat.permission(data.id, action);
+      if (!res.resolved) {
+        setError("Permission request expired.");
+        return;
+      }
+      setResolved(action);
     } catch {
-      // ignore
+      setError("Could not resolve permission request.");
     } finally {
       setResolving(false);
     }
   }
+
+  const description = data.description ?? data.prompt;
 
   return (
     <div className="flex w-full justify-start">
@@ -137,34 +147,55 @@ function PermissionPrompt({
             Tool: <span className="font-medium text-foreground">{data.tool}</span>
           </p>
         )}
-        {data.description && (
-          <p className="mt-1 text-sm text-foreground">{data.description}</p>
+        {description && (
+          <p className="mt-1 whitespace-pre-wrap text-sm text-foreground">{description}</p>
         )}
-        <div className="mt-3 flex items-center gap-2">
-          <Button
-            size="sm"
-            className="h-7 gap-1 text-xs"
-            disabled={resolving}
-            onClick={() => handle("allow")}
-          >
-            {resolving ? (
-              <Loader2 className="h-3 w-3 animate-spin" />
-            ) : (
+        {resolved ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            {resolved === "always"
+              ? "Always allowed and saved."
+              : resolved === "yes"
+                ? "Allowed for this request."
+                : "Denied."}
+          </p>
+        ) : (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              disabled={resolving}
+              onClick={() => handle("yes")}
+            >
+              {resolving ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Check className="h-3 w-3" />
+              )}
+              Allow Once
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1 text-xs"
+              disabled={resolving}
+              onClick={() => handle("always")}
+            >
               <Check className="h-3 w-3" />
-            )}
-            Allow
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-7 gap-1 text-xs"
-            disabled={resolving}
-            onClick={() => handle("deny")}
-          >
-            <X className="h-3 w-3" />
-            Deny
-          </Button>
-        </div>
+              Always
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1 text-xs"
+              disabled={resolving}
+              onClick={() => handle("no")}
+            >
+              <X className="h-3 w-3" />
+              Deny
+            </Button>
+          </div>
+        )}
+        {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
       </div>
     </div>
   );
@@ -706,7 +737,7 @@ export function ChatPage() {
                     if (msg.role === "system") {
                       try {
                         const parsed = JSON.parse(msg.content);
-                        if (parsed.id && (parsed.tool || parsed.description)) {
+                        if (parsed.id && (parsed.tool || parsed.description || parsed.prompt)) {
                           return <PermissionPrompt key={msg.id} data={parsed} />;
                         }
                       } catch {

--- a/ui/src/pages/Permissions.tsx
+++ b/ui/src/pages/Permissions.tsx
@@ -3,6 +3,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   Shield,
   Save,
+  Plus,
+  Trash2,
   Loader2,
   HardDrive,
   Terminal,
@@ -19,6 +21,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import api from "@/lib/api";
@@ -165,7 +168,14 @@ function CapabilitySkeleton() {
 
 /* ── Types ──────────────────────────────────────────────────── */
 
-type Capabilities = Record<string, Record<string, boolean>>;
+interface FileScope {
+  path: string;
+  read: boolean;
+  write: boolean;
+}
+
+type CapabilityGroup = Record<string, unknown>;
+type Capabilities = Record<string, CapabilityGroup>;
 
 /* ── Main Page ──────────────────────────────────────────────── */
 
@@ -174,6 +184,7 @@ export function PermissionsPage() {
   const [originalCapabilities, setOriginalCapabilities] = useState<Capabilities>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [newScopePath, setNewScopePath] = useState("/home/operacional/workspace");
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   const toast = useCallback((type: "success" | "error", message: string) => {
@@ -215,6 +226,55 @@ export function PermissionsPage() {
     }));
   };
 
+  const filesystemScopes = useMemo<FileScope[]>(() => {
+    const scopes = capabilities.filesystem?.scopes;
+    return Array.isArray(scopes) ? (scopes as FileScope[]) : [];
+  }, [capabilities]);
+
+  const updateFilesystemScopes = (scopes: FileScope[]) => {
+    setCapabilities((prev) => ({
+      ...prev,
+      filesystem: {
+        ...prev.filesystem,
+        enabled: prev.filesystem?.enabled ?? true,
+        scopes,
+      },
+    }));
+  };
+
+  const handleAddScope = () => {
+    const path = newScopePath.trim();
+    if (!path) {
+      toast("error", "Path is required");
+      return;
+    }
+
+    const existingIndex = filesystemScopes.findIndex((scope) => scope.path === path);
+    if (existingIndex >= 0) {
+      updateFilesystemScopes(
+        filesystemScopes.map((scope, index) =>
+          index === existingIndex ? { ...scope, read: true } : scope
+        )
+      );
+      toast("success", "Scope already exists; read access enabled");
+      return;
+    }
+
+    updateFilesystemScopes([...filesystemScopes, { path, read: true, write: false }]);
+  };
+
+  const handleScopeToggle = (index: number, key: "read" | "write", checked: boolean) => {
+    updateFilesystemScopes(
+      filesystemScopes.map((scope, scopeIndex) =>
+        scopeIndex === index ? { ...scope, [key]: checked } : scope
+      )
+    );
+  };
+
+  const handleRemoveScope = (index: number) => {
+    updateFilesystemScopes(filesystemScopes.filter((_, scopeIndex) => scopeIndex !== index));
+  };
+
   const handleSave = async () => {
     setSaving(true);
     try {
@@ -248,7 +308,9 @@ export function PermissionsPage() {
         ? groupValue
         : {};
 
-      const permEntries = Object.entries(perms).map(([permKey, permValue]) => {
+      const permEntries = Object.entries(perms).filter(([, permValue]) => {
+        return typeof permValue === "boolean";
+      }).map(([permKey, permValue]) => {
         const permMeta = meta?.permissions[permKey];
         return {
           key: permKey,
@@ -322,12 +384,97 @@ export function PermissionsPage() {
         </motion.div>
       ) : (
         <div className="space-y-4">
+          <motion.div
+            custom={0}
+            variants={fadeUp}
+            initial="hidden"
+            animate="visible"
+          >
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">
+                    <HardDrive className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <div>
+                    <CardTitle className="text-base">Filesystem Scopes</CardTitle>
+                    <CardDescription>
+                      Add folders Mercury can read or write from the web agent
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Input
+                    value={newScopePath}
+                    onChange={(event) => setNewScopePath(event.target.value)}
+                    placeholder="/home/operacional/workspace/project"
+                  />
+                  <Button type="button" onClick={handleAddScope} className="gap-2">
+                    <Plus className="h-4 w-4" />
+                    Add Read Scope
+                  </Button>
+                </div>
+
+                <div className="divide-y divide-border rounded-md border border-border">
+                  {filesystemScopes.length === 0 ? (
+                    <p className="px-3 py-4 text-sm text-muted-foreground">
+                      No filesystem scopes configured.
+                    </p>
+                  ) : (
+                    filesystemScopes.map((scope, index) => (
+                      <div
+                        key={`${scope.path}-${index}`}
+                        className="flex flex-col gap-3 px-3 py-3 lg:flex-row lg:items-center lg:justify-between"
+                      >
+                        <code className="break-all rounded bg-muted px-2 py-1 text-xs text-foreground">
+                          {scope.path}
+                        </code>
+                        <div className="flex flex-wrap items-center gap-4">
+                          <label className="flex items-center gap-2 text-sm text-foreground">
+                            <Switch
+                              checked={scope.read}
+                              onCheckedChange={(checked) =>
+                                handleScopeToggle(index, "read", checked)
+                              }
+                            />
+                            Read
+                          </label>
+                          <label className="flex items-center gap-2 text-sm text-foreground">
+                            <Switch
+                              checked={scope.write}
+                              onCheckedChange={(checked) =>
+                                handleScopeToggle(index, "write", checked)
+                              }
+                            />
+                            Write
+                          </label>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            className="h-8 gap-1 text-destructive"
+                            onClick={() => handleRemoveScope(index)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                            Remove
+                          </Button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+
           {capabilityGroups.map((group, i) => {
             const Icon = group.icon;
             return (
               <motion.div
                 key={group.key}
-                custom={i}
+                custom={i + 1}
                 variants={fadeUp}
                 initial="hidden"
                 animate="visible"


### PR DESCRIPTION
## Summary
- force the ChatGPT Web provider through non-persistent responses and strip stale item references before calling the Codex responses endpoint
- pass OpenAI provider options with store=false so tool-call continuations are serialized inline
- fix web permission approval actions to use yes/always/no, render prompt text, and expose filesystem scopes in the Permissions page
- wire the Permissions API to the live PermissionManager so web changes take effect immediately

## Verification
- npm run -s typecheck
- npm test -s
- npm run -s build

## Context
The ChatGPT Web Codex endpoint rejects persisted responses with store=true, but tool-call continuations could still include item_reference rows. That produced failures like: Item with id 'rs_*' not found. The web permissions UI also emitted allow/deny actions while the backend waited for yes/always/no, so approval prompts could not be resolved from the dashboard.