### PR TITLE
docs: refresh current stable version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <strong>🔖 Current Stable: v1.1.6</strong>
+  <strong>🔖 Current Stable: v1.1.9</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- update the README badge line from `v1.1.6` to the current stable release `v1.1.9`

## Why
The repository README still advertises `v1.1.6` as the current stable release, but the latest published Mercury release is `v1.1.9`.

## Testing
- `gh release list --repo cosmicstack-labs/mercury-agent --limit 10`
- `grep -n 'Current Stable' README.md`
