### PR TITLE
feat: add /new command to reset conversation context in Telegram and other channels

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -264,6 +264,7 @@ export class TelegramChannel extends BaseChannel {
 
     const commands = [
       { command: 'start', description: 'Request Telegram access to this Mercury instance' },
+      { command: 'new', description: 'Start a new conversation (clear context)' },
       { command: 'help', description: 'Show available commands' },
       { command: 'status', description: 'Show agent config, budget, and uptime' },
       { command: 'progress', description: 'Live status for the current task' },

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -2966,13 +2966,24 @@ Is this productive iteration or a stuck loop?`,
   }
 
   private async handleChatCommand(content: string, channelType: string, channelId: string): Promise<boolean> {
-    const trimmed = content.trim();
+    let trimmed = content.trim();
+    if (trimmed.toLowerCase().startsWith('/mercury ')) {
+      trimmed = '/' + trimmed.slice('/mercury '.length).trim();
+    } else if (trimmed.toLowerCase() === '/mercury') {
+      trimmed = '/help';
+    }
     const cmd = trimmed.toLowerCase();
     const channel = this.channels.get(channelType as any);
     if (!channel) return false;
 
     const ctx = this.capabilities.getChatCommandContext();
     if (!ctx) return false;
+
+    if (cmd === '/new' || cmd === '/clear') {
+      this.shortTerm.clear(channelId);
+      await channel.send('🔄 Conversation context cleared. Starting a fresh session!', channelId);
+      return true;
+    }
 
     if (cmd === '/help') {
       const helpText = channelType === 'telegram' ? getTelegramHelp() : channelType === 'discord' ? getDiscordHelp() : channelType === 'slack' ? getSlackHelp() : ctx.manual();

--- a/src/utils/manual.ts
+++ b/src/utils/manual.ts
@@ -111,6 +111,7 @@ export function getManual(): string {
     ['/', 'Open the CLI command picker with arrow-key navigation'],
     ['/menu', 'Open the CLI command picker with arrow-key navigation'],
     ['/help', 'Show this manual'],
+    ['/new', 'Start a new conversation (clear context)'],
     ['/status', 'Show config and budget info'],
     ['/progress', 'Show live status for the current long task'],
     ['/telegram', 'CLI chat only: open the Telegram management menu'],
@@ -266,6 +267,7 @@ export function getTelegramHelp(): string {
 
   lines.push('**General**');
   lines.push('/help — Show this command list');
+  lines.push('/new — Start a new conversation (clear context)');
   lines.push('/status — Config, budget, and uptime');
   lines.push('/progress — Live status for the current task');
   lines.push('/permissions — Switch Ask Me / Allow All mode');
@@ -353,6 +355,7 @@ export function getDiscordHelp(): string {
 
   lines.push('**General**');
   lines.push('/help \u2014 Show this command list');
+  lines.push('/new \u2014 Start a new conversation (clear context)');
   lines.push('/status \u2014 Config, budget, and uptime');
   lines.push('/progress \u2014 Live status for the current task');
   lines.push('/permissions \u2014 Switch Ask Me / Allow All mode');
@@ -392,6 +395,7 @@ export function getSlackHelp(): string {
 
   lines.push('**General**');
   lines.push('/mercury help \u2014 Show this command list');
+  lines.push('/mercury new \u2014 Start a new conversation (clear context)');
   lines.push('/mercury status \u2014 Config, budget, and uptime');
   lines.push('/mercury stop \u2014 Stop all agents');
   lines.push('');

--- a/src/utils/tokens.test.ts
+++ b/src/utils/tokens.test.ts
@@ -91,7 +91,7 @@ describe('TokenBudget hardening', () => {
     const budget = new TokenBudget({ tokens: { dailyBudget: 200_000 } } as any);
 
     expect(budget.getDailyUsed()).toBe(100);
-    expect(budget.getStatusText()).toContain('100 / 200,000 used');
+    expect(budget.getStatusText()).toMatch(/100\s*\/\s*200[,\s\u00a0]?000\s*used/);
     expect(budget.getStatusText()).not.toContain('NaN');
 
     const persisted = JSON.parse(readFileSync(usagePath, 'utf-8')) as { dailyUsed: number };


### PR DESCRIPTION
Resolves #38.

Adds a `/new` (and `/clear`) chat command that clears the short-term conversation context for the specific channel. The command is also registered in the Telegram Bot commands menu and documented in the manual files for CLI, Telegram, Discord, and Slack.

Additionally:
1. Fixed a bug where Slack commands starting with `/mercury ` were not being normalized to standard commands.
2. Fixed a locale-dependent separator issue in `tokens.test.ts` that caused tests to fail on systems using non-comma thousands separators.